### PR TITLE
SCRUM-21 feat: add danger and danger_small variants to Typography

### DIFF
--- a/lib/components/atoms/Typography/Typography.module.scss
+++ b/lib/components/atoms/Typography/Typography.module.scss
@@ -111,3 +111,21 @@
     var(--color-primary-500)
   );
 }
+
+.danger {
+  @include mixins.typography-with-color(
+    var(--font-size-s),
+    var(--font-weight-regular),
+    var(--line-height-m),
+    var(--color-danger-500)
+  );
+}
+
+.danger_small {
+  @include mixins.typography-with-color(
+    var(--font-size-xs),
+    var(--font-weight-regular),
+    var(--line-height-s),
+    var(--color-danger-500)
+  );
+}

--- a/lib/components/atoms/Typography/Typography.stories.tsx
+++ b/lib/components/atoms/Typography/Typography.stories.tsx
@@ -20,6 +20,8 @@ const meta: Meta<typeof Typography> = {
         'semibold_small_text',
         'regular_link',
         'small_link',
+        'danger',
+        'danger_small',
       ],
     },
   },
@@ -136,5 +138,19 @@ export const Small_link: Story = {
     asChild: true,
     children: <a>Regular 12px link</a>,
     variant: 'small_link',
+  },
+}
+
+export const Danger_text: Story = {
+  args: {
+    children: 'Error message',
+    variant: 'danger',
+  },
+}
+
+export const Small_danger_text: Story = {
+  args: {
+    children: 'Small error message',
+    variant: 'danger_small',
   },
 }

--- a/lib/components/atoms/Typography/Typography.tsx
+++ b/lib/components/atoms/Typography/Typography.tsx
@@ -19,6 +19,8 @@ type TypographyVariant =
   | 'semibold_small_text'
   | 'regular_link'
   | 'small_link'
+  | 'danger'
+  | 'danger_small'
 
 type Props = {
   asChild?: boolean


### PR DESCRIPTION
Добавляет варианты danger и danger_small в компонент Typography.

![image](https://github.com/user-attachments/assets/0e8ed655-e87c-4b0d-adb2-841d5bdd731b)
