### PR TITLE
🔧 Add GitHub Action to Build and Deploy Storybook from main to storybook-deploy

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-
+        
         uses: actions/checkout@v4
 
       - name: Merge dev -> storybook-deploy 🚀

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,0 +1,20 @@
+name: Build and Deploy Storybook
+on:
+  push:
+    branches:
+      - 'main'
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+
+        uses: actions/checkout@v4
+
+      - name: Merge dev -> storybook-deploy 🚀
+        uses: devmasx/merge-branch@1.4.0
+        with:
+          type: now
+          from_branch: main
+          target_branch: storybook-deploy
+          github_token: ${{ github.token }}


### PR DESCRIPTION
📦 **What’s Added/Changed?**  
Added a GitHub Actions workflow that builds and deploys Storybook by automatically merging the `main` branch into `storybook-deploy`.

🧱 **Type of Changes**  
🧰 Infrastructure / Configuration

🧪 **Verification**  
- Verified that the workflow triggers correctly on pushes to `main`.  
- Automatically merges `main` → `storybook-deploy` using `devmasx/merge-branch`.

🔍 **Notes for Reviewers**  
- Ensure the repository has the required permissions to push to the `storybook-deploy` branch.  
- This setup is useful for deploying Storybook via GitHub Pages or similar services.

🔗 **Related Issues/Tickets**  
_None._

✅ **Pre-Merge Checklist**  
- [x] CI passes successfully  
- [x] No debug logs, TODOs, or commented-out code remain  
- [x] All discussions resolved  
- [x] At least two approvals  
- [x] Last commit is not self-approved  

