### PR TITLE
SCRUM-62 feat(input): add auto-generated fallback id using useId for …

### DIFF
--- a/lib/components/molecules/Input/Input.tsx
+++ b/lib/components/molecules/Input/Input.tsx
@@ -1,4 +1,4 @@
-import { ComponentPropsWithoutRef, forwardRef, useState } from 'react'
+import { ComponentPropsWithoutRef, forwardRef, useId, useState } from 'react'
 
 import Eye from 'assets/icons/components/Eye'
 import EyeOff from 'assets/icons/components/EyeOff'
@@ -84,13 +84,15 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
         }
       }
     }
+    const generatedId = useId()
 
+    const inputId = id ?? generatedId
     return (
       <div className={clsx(s.inputWrapper, disabled && s.disabled)}>
         {label && (
           <LabelRadix
             label={label}
-            htmlFor={id}
+            htmlFor={inputId}
             typographyVariant={'regular_14'}
             required={required}
             disabled={disabled}
@@ -109,7 +111,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
               type={type}
               placeholder={placeholder}
               ref={ref}
-              id={id}
+              id={inputId}
               className={clsx(s.input, error && s.error, className)}
               disabled={disabled}
               required={required}


### PR DESCRIPTION
## 📦 What’s Added/Changed?

Added fallback `id` generation in the `Input` component using React's `useId` hook to ensure consistent labeling and improve accessibility when an `id` prop is not provided.

## 🧱 Type of Changes

- ♻️ Enhancement to an existing component  
- 📖 Documentation / Storybook *(if applicable)*  
- 🧪 Tests (unit/visual) *(if applicable)*

## 🧪 Verification

- [ ] Tests added or updated *(if applicable)*  
- [x] Visually checked in Storybook  
- [x] Verified in consuming project *(if relevant)*

## 🔍 Notes for Reviewers

This enhancement ensures the `Input` remains accessible and compliant with HTML form standards even when `id` is not explicitly passed. It also prevents potential issues with `<label>` not being linked to `<input>` in dynamic or complex form setups.

## 🔗 Related Issues/Tickets

Closes #NNN *(replace with issue number if applicable)*

## ✅ Pre-Merge Checklist

- [x] Component is covered by tests *(if applicable)*  
- [x] Docs / Storybook updated *(if applicable)*  
- [x] All CI checks pass  
- [x] No temporary logs, TODOs, or commented-out code  
- [x] All discussions resolved  
- [x] 2 approvals received  
- [x] Last commit is not self-approved  

---
