### PR TITLE
SCRUM-64 refactor(components): add missing displayName to forwardRef …

### DIFF
--- a/lib/assets/icons/components/ArrowBack.tsx
+++ b/lib/assets/icons/components/ArrowBack.tsx
@@ -31,3 +31,4 @@ const ArrowBack = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default ArrowBack
+ArrowBack.displayName = 'ArrowBack'

--- a/lib/assets/icons/components/ArrowBackSimple.tsx
+++ b/lib/assets/icons/components/ArrowBackSimple.tsx
@@ -40,3 +40,4 @@ const ArrowBackSimple = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) =
 })
 
 export default ArrowBackSimple
+ArrowBackSimple.displayName = 'ArrowBackSimple'

--- a/lib/assets/icons/components/ArrowDownSimple.tsx
+++ b/lib/assets/icons/components/ArrowDownSimple.tsx
@@ -40,3 +40,4 @@ const ArrowDownSimple = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) =
 })
 
 export default ArrowDownSimple
+ArrowDownSimple.displayName = 'ArrowDownSimple'

--- a/lib/assets/icons/components/ArrowForward.tsx
+++ b/lib/assets/icons/components/ArrowForward.tsx
@@ -38,3 +38,4 @@ const ArrowForward = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default ArrowForward
+ArrowForward.displayName = 'ArrowForward'

--- a/lib/assets/icons/components/ArrowForwardSimple.tsx
+++ b/lib/assets/icons/components/ArrowForwardSimple.tsx
@@ -40,3 +40,4 @@ const ArrowIosForward = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) =
 })
 
 export default ArrowIosForward
+ArrowIosForward.displayName = 'ArrowIosForward'

--- a/lib/assets/icons/components/ArrowUpSimple.tsx
+++ b/lib/assets/icons/components/ArrowUpSimple.tsx
@@ -40,3 +40,4 @@ const ArrowUpSimple = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => 
 })
 
 export default ArrowUpSimple
+ArrowUpSimple.displayName = 'ArrowUpSimple'

--- a/lib/assets/icons/components/Bell.tsx
+++ b/lib/assets/icons/components/Bell.tsx
@@ -58,3 +58,4 @@ const Bell = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Bell
+Bell.displayName = 'Bell'

--- a/lib/assets/icons/components/BellOutline.tsx
+++ b/lib/assets/icons/components/BellOutline.tsx
@@ -42,3 +42,4 @@ const BellOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default BellOutline
+BellOutline.displayName = 'BellOutline'

--- a/lib/assets/icons/components/Block.tsx
+++ b/lib/assets/icons/components/Block.tsx
@@ -45,3 +45,4 @@ const Block = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Block
+Block.displayName = 'Block'

--- a/lib/assets/icons/components/BlockFull.tsx
+++ b/lib/assets/icons/components/BlockFull.tsx
@@ -39,3 +39,4 @@ const BlockFull = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default BlockFull
+BlockFull.displayName = 'BlockFull'

--- a/lib/assets/icons/components/Bookmark.tsx
+++ b/lib/assets/icons/components/Bookmark.tsx
@@ -40,3 +40,4 @@ const Bookmark = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Bookmark
+Bookmark.displayName = 'Bookmark'

--- a/lib/assets/icons/components/BookmarkOutline.tsx
+++ b/lib/assets/icons/components/BookmarkOutline.tsx
@@ -40,3 +40,4 @@ const BookmarkOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) =
 })
 
 export default BookmarkOutline
+BookmarkOutline.displayName = 'BookmarkOutline'

--- a/lib/assets/icons/components/Calendar.tsx
+++ b/lib/assets/icons/components/Calendar.tsx
@@ -40,3 +40,4 @@ const Calendar = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Calendar
+Calendar.displayName = 'Calendar'

--- a/lib/assets/icons/components/CalendarOutline.tsx
+++ b/lib/assets/icons/components/CalendarOutline.tsx
@@ -40,3 +40,5 @@ const CalendarOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) =
 })
 
 export default CalendarOutline
+
+CalendarOutline.displayName = 'CalendarOutline'

--- a/lib/assets/icons/components/Checkmark.tsx
+++ b/lib/assets/icons/components/Checkmark.tsx
@@ -40,3 +40,4 @@ const Checkmark = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Checkmark
+Checkmark.displayName = 'Checkmark'

--- a/lib/assets/icons/components/Close.tsx
+++ b/lib/assets/icons/components/Close.tsx
@@ -40,3 +40,4 @@ const Close = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Close
+Close.displayName = 'Close'

--- a/lib/assets/icons/components/ColorPalette.tsx
+++ b/lib/assets/icons/components/ColorPalette.tsx
@@ -44,3 +44,5 @@ const ColorPalette = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default ColorPalette
+
+ColorPalette.displayName = 'ColorPalette'

--- a/lib/assets/icons/components/Copy.tsx
+++ b/lib/assets/icons/components/Copy.tsx
@@ -40,3 +40,4 @@ const Copy = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Copy
+Copy.displayName = 'Copy'

--- a/lib/assets/icons/components/CopyOutline.tsx
+++ b/lib/assets/icons/components/CopyOutline.tsx
@@ -44,3 +44,4 @@ const CopyOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default CopyOutline
+CopyOutline.displayName = 'CopyOutline'

--- a/lib/assets/icons/components/CreditCard.tsx
+++ b/lib/assets/icons/components/CreditCard.tsx
@@ -40,3 +40,4 @@ const CreditCard = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default CreditCard
+CreditCard.displayName = 'CreditCard'

--- a/lib/assets/icons/components/CreditCardOutline.tsx
+++ b/lib/assets/icons/components/CreditCardOutline.tsx
@@ -42,3 +42,4 @@ const CreditCardOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref)
 })
 
 export default CreditCardOutline
+CreditCardOutline.displayName = 'CreditCardOutline'

--- a/lib/assets/icons/components/DoneAll.tsx
+++ b/lib/assets/icons/components/DoneAll.tsx
@@ -40,3 +40,4 @@ const DoneAllOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) =>
 })
 
 export default DoneAllOutline
+DoneAllOutline.displayName = 'DoneAllOutline'

--- a/lib/assets/icons/components/Edit.tsx
+++ b/lib/assets/icons/components/Edit.tsx
@@ -39,3 +39,4 @@ const Edit = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Edit
+Edit.displayName = 'Edit'

--- a/lib/assets/icons/components/EditOutline.tsx
+++ b/lib/assets/icons/components/EditOutline.tsx
@@ -39,3 +39,4 @@ const EditOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default EditOutline
+EditOutline.displayName = 'EditOutline'

--- a/lib/assets/icons/components/Email.tsx
+++ b/lib/assets/icons/components/Email.tsx
@@ -40,3 +40,4 @@ const Email = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Email
+Email.displayName = 'Email'

--- a/lib/assets/icons/components/EmailOutline.tsx
+++ b/lib/assets/icons/components/EmailOutline.tsx
@@ -40,3 +40,4 @@ const EmailOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default EmailOutline
+EmailOutline.displayName = 'EmailOutline'

--- a/lib/assets/icons/components/Expand.tsx
+++ b/lib/assets/icons/components/Expand.tsx
@@ -39,3 +39,4 @@ const Expand = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Expand
+Expand.displayName = 'Expand'

--- a/lib/assets/icons/components/Eye.tsx
+++ b/lib/assets/icons/components/Eye.tsx
@@ -40,3 +40,4 @@ const Eye = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Eye
+Eye.displayName = 'Eye'

--- a/lib/assets/icons/components/EyeOff.tsx
+++ b/lib/assets/icons/components/EyeOff.tsx
@@ -44,3 +44,4 @@ const EyeOff = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default EyeOff
+EyeOff.displayName = 'EyeOff'

--- a/lib/assets/icons/components/EyeOffOutline.tsx
+++ b/lib/assets/icons/components/EyeOffOutline.tsx
@@ -44,3 +44,4 @@ const EyeOffOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => 
 })
 
 export default EyeOffOutline
+EyeOffOutline.displayName = 'EyeOffOutline'

--- a/lib/assets/icons/components/EyeOutline.tsx
+++ b/lib/assets/icons/components/EyeOutline.tsx
@@ -44,3 +44,4 @@ const EyeOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default EyeOutline
+EyeOutline.displayName = 'EyeOutline'

--- a/lib/assets/icons/components/Facebook.tsx
+++ b/lib/assets/icons/components/Facebook.tsx
@@ -41,3 +41,4 @@ const Facebook = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Facebook
+Facebook.displayName = 'Facebook'

--- a/lib/assets/icons/components/GitHub.tsx
+++ b/lib/assets/icons/components/GitHub.tsx
@@ -40,3 +40,4 @@ const GitHub = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default GitHub
+GitHub.displayName = 'GitHub'

--- a/lib/assets/icons/components/Google.tsx
+++ b/lib/assets/icons/components/Google.tsx
@@ -58,3 +58,4 @@ const Google = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Google
+Google.displayName = 'Google'

--- a/lib/assets/icons/components/Heart.tsx
+++ b/lib/assets/icons/components/Heart.tsx
@@ -40,3 +40,4 @@ const Heart = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Heart
+Heart.displayName = 'Heart'

--- a/lib/assets/icons/components/HeartOutline.tsx
+++ b/lib/assets/icons/components/HeartOutline.tsx
@@ -40,3 +40,4 @@ const HeartOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default HeartOutline
+HeartOutline.displayName = 'HeartOutline'

--- a/lib/assets/icons/components/Home.tsx
+++ b/lib/assets/icons/components/Home.tsx
@@ -40,3 +40,4 @@ const Home = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Home
+Home.displayName = 'Home'

--- a/lib/assets/icons/components/HomeOutline.tsx
+++ b/lib/assets/icons/components/HomeOutline.tsx
@@ -40,3 +40,4 @@ const HomeOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default HomeOutline
+HomeOutline.displayName = 'HomeOutline'

--- a/lib/assets/icons/components/Image.tsx
+++ b/lib/assets/icons/components/Image.tsx
@@ -40,3 +40,4 @@ const Image = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Image
+Image.displayName = 'Image'

--- a/lib/assets/icons/components/ImageOutline.tsx
+++ b/lib/assets/icons/components/ImageOutline.tsx
@@ -40,3 +40,4 @@ const ImageOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default ImageOutline
+ImageOutline.displayName = 'ImageOutline'

--- a/lib/assets/icons/components/Layers.tsx
+++ b/lib/assets/icons/components/Layers.tsx
@@ -49,3 +49,4 @@ const Layers = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Layers
+Layers.displayName = 'Layers'

--- a/lib/assets/icons/components/LayersOutline.tsx
+++ b/lib/assets/icons/components/LayersOutline.tsx
@@ -40,3 +40,4 @@ const LayersOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => 
 })
 
 export default LayersOutline
+LayersOutline.displayName = 'LayersOutline'

--- a/lib/assets/icons/components/LogOut.tsx
+++ b/lib/assets/icons/components/LogOut.tsx
@@ -39,3 +39,4 @@ const LogOut = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default LogOut
+LogOut.displayName = 'LogOut'

--- a/lib/assets/icons/components/Maximize.tsx
+++ b/lib/assets/icons/components/Maximize.tsx
@@ -40,3 +40,4 @@ const Maximize = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Maximize
+Maximize.displayName = 'Maximize'

--- a/lib/assets/icons/components/MaximizeOutline.tsx
+++ b/lib/assets/icons/components/MaximizeOutline.tsx
@@ -42,3 +42,4 @@ const MaximizeOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) =
 })
 
 export default MaximizeOutline
+MaximizeOutline.displayName = 'MaximizeOutline'

--- a/lib/assets/icons/components/MenuOutline.tsx
+++ b/lib/assets/icons/components/MenuOutline.tsx
@@ -39,3 +39,4 @@ const MenuOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default MenuOutline
+MenuOutline.displayName = 'MenuOutline'

--- a/lib/assets/icons/components/MessageCircle.tsx
+++ b/lib/assets/icons/components/MessageCircle.tsx
@@ -40,3 +40,5 @@ const MessageCircle = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => 
 })
 
 export default MessageCircle
+
+MessageCircle.displayName = 'MessageCircle'

--- a/lib/assets/icons/components/MessageCircleOutline.tsx
+++ b/lib/assets/icons/components/MessageCircleOutline.tsx
@@ -44,3 +44,4 @@ const MessageCircleOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, r
 })
 
 export default MessageCircleOutline
+MessageCircleOutline.displayName = 'MessageCircleOutline'

--- a/lib/assets/icons/components/Mic.tsx
+++ b/lib/assets/icons/components/Mic.tsx
@@ -40,3 +40,4 @@ const Mic = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Mic
+Mic.displayName = 'Mic'

--- a/lib/assets/icons/components/MicOutline.tsx
+++ b/lib/assets/icons/components/MicOutline.tsx
@@ -44,3 +44,4 @@ const MicOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default MicOutline
+MicOutline.displayName = 'MicOutline'

--- a/lib/assets/icons/components/MoreHorizontal.tsx
+++ b/lib/assets/icons/components/MoreHorizontal.tsx
@@ -39,3 +39,4 @@ const MoreHorizontal = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) =>
 })
 
 export default MoreHorizontal
+MoreHorizontal.displayName = 'MoreHorizontal'

--- a/lib/assets/icons/components/Paid.tsx
+++ b/lib/assets/icons/components/Paid.tsx
@@ -48,3 +48,4 @@ const Paid = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Paid
+Paid.displayName = 'Paid'

--- a/lib/assets/icons/components/PaperPlane.tsx
+++ b/lib/assets/icons/components/PaperPlane.tsx
@@ -40,3 +40,4 @@ const PaperPlane = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default PaperPlane
+PaperPlane.displayName = 'PaperPlane'

--- a/lib/assets/icons/components/PauseCircle.tsx
+++ b/lib/assets/icons/components/PauseCircle.tsx
@@ -40,3 +40,4 @@ const PauseCircle = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default PauseCircle
+PauseCircle.displayName = 'PauseCircle'

--- a/lib/assets/icons/components/PauseCircleOutline.tsx
+++ b/lib/assets/icons/components/PauseCircleOutline.tsx
@@ -42,3 +42,4 @@ const PauseCircleOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref
 })
 
 export default PauseCircleOutline
+PauseCircleOutline.displayName = 'PauseCircleOutline'

--- a/lib/assets/icons/components/PayPal.tsx
+++ b/lib/assets/icons/components/PayPal.tsx
@@ -81,3 +81,4 @@ const PayPal = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default PayPal
+PayPal.displayName = 'PayPal'

--- a/lib/assets/icons/components/Person.tsx
+++ b/lib/assets/icons/components/Person.tsx
@@ -39,3 +39,4 @@ const Person = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Person
+Person.displayName = 'Person'

--- a/lib/assets/icons/components/PersonAdd.tsx
+++ b/lib/assets/icons/components/PersonAdd.tsx
@@ -39,3 +39,4 @@ const PersonAdd = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default PersonAdd
+PersonAdd.displayName = 'PersonAdd'

--- a/lib/assets/icons/components/PersonAddOutline.tsx
+++ b/lib/assets/icons/components/PersonAddOutline.tsx
@@ -39,3 +39,4 @@ const PersonAddOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) 
 })
 
 export default PersonAddOutline
+PersonAddOutline.displayName = 'PersonAddOutline'

--- a/lib/assets/icons/components/PersonOutline.tsx
+++ b/lib/assets/icons/components/PersonOutline.tsx
@@ -39,3 +39,4 @@ const PersonOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => 
 })
 
 export default PersonOutline
+PersonOutline.displayName = 'PersonOutline'

--- a/lib/assets/icons/components/PersonRemove.tsx
+++ b/lib/assets/icons/components/PersonRemove.tsx
@@ -39,3 +39,4 @@ const PersonRemove = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default PersonRemove
+PersonRemove.displayName = 'PersonRemove'

--- a/lib/assets/icons/components/PersonRemoveOutline.tsx
+++ b/lib/assets/icons/components/PersonRemoveOutline.tsx
@@ -39,3 +39,4 @@ const PersonRemoveOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, re
 })
 
 export default PersonRemoveOutline
+PersonRemoveOutline.displayName = 'PersonRemoveOutline'

--- a/lib/assets/icons/components/Pin.tsx
+++ b/lib/assets/icons/components/Pin.tsx
@@ -40,3 +40,4 @@ const Pin = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Pin
+Pin.displayName = 'Pin'

--- a/lib/assets/icons/components/PinOutline.tsx
+++ b/lib/assets/icons/components/PinOutline.tsx
@@ -44,3 +44,4 @@ const PinOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default PinOutline
+PinOutline.displayName = 'PinOutline'

--- a/lib/assets/icons/components/PlayCircle.tsx
+++ b/lib/assets/icons/components/PlayCircle.tsx
@@ -40,3 +40,4 @@ const PlayCircle = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default PlayCircle
+PlayCircle.displayName = 'PlayCircle'

--- a/lib/assets/icons/components/PlayCircleOutline.tsx
+++ b/lib/assets/icons/components/PlayCircleOutline.tsx
@@ -42,3 +42,4 @@ const PlayCircleOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref)
 })
 
 export default PlayCircleOutline
+PlayCircleOutline.displayName = 'PlayCircleOutline'

--- a/lib/assets/icons/components/PlusCircle.tsx
+++ b/lib/assets/icons/components/PlusCircle.tsx
@@ -40,3 +40,4 @@ const PlusCircle = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default PlusCircle
+PlusCircle.displayName = 'PlusCircle'

--- a/lib/assets/icons/components/PlusCircleOutline.tsx
+++ b/lib/assets/icons/components/PlusCircleOutline.tsx
@@ -40,3 +40,4 @@ const PlusCircleOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref)
 })
 
 export default PlusCircleOutline
+PlusCircleOutline.displayName = 'PlusCircleOutline'

--- a/lib/assets/icons/components/PlusSquare.tsx
+++ b/lib/assets/icons/components/PlusSquare.tsx
@@ -40,3 +40,4 @@ const PlusSquare = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default PlusSquare
+PlusSquare.displayName = 'PlusSquare'

--- a/lib/assets/icons/components/PlusSquareOutline.tsx
+++ b/lib/assets/icons/components/PlusSquareOutline.tsx
@@ -42,3 +42,4 @@ const PlusSquareOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref)
 })
 
 export default PlusSquareOutline
+PlusSquareOutline.displayName = 'PlusSquareOutline'

--- a/lib/assets/icons/components/RadioButtonChecked.tsx
+++ b/lib/assets/icons/components/RadioButtonChecked.tsx
@@ -40,3 +40,4 @@ const RadioButtonChecked = forwardRef<HTMLSpanElement, IconProps>((allProps, ref
 })
 
 export default RadioButtonChecked
+RadioButtonChecked.displayName = 'RadioButtonChecked'

--- a/lib/assets/icons/components/RadioButtonUnchecked.tsx
+++ b/lib/assets/icons/components/RadioButtonUnchecked.tsx
@@ -40,3 +40,4 @@ const RadioButtonUnchecked = forwardRef<HTMLSpanElement, IconProps>((allProps, r
 })
 
 export default RadioButtonUnchecked
+RadioButtonUnchecked.displayName = 'RadioButtonUnchecked'

--- a/lib/assets/icons/components/Recaptcha.tsx
+++ b/lib/assets/icons/components/Recaptcha.tsx
@@ -51,3 +51,4 @@ const RecaptchaIcon = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => 
 })
 
 export default RecaptchaIcon
+RecaptchaIcon.displayName = 'RecaptchaIcon'

--- a/lib/assets/icons/components/RussiaFlag.tsx
+++ b/lib/assets/icons/components/RussiaFlag.tsx
@@ -48,3 +48,4 @@ const RussiaFlag = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default RussiaFlag
+RussiaFlag.displayName = 'RussiaFlag'

--- a/lib/assets/icons/components/Search.tsx
+++ b/lib/assets/icons/components/Search.tsx
@@ -40,3 +40,4 @@ const Search = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Search
+Search.displayName = 'Search'

--- a/lib/assets/icons/components/Settings.tsx
+++ b/lib/assets/icons/components/Settings.tsx
@@ -40,3 +40,4 @@ const Settings = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Settings
+Settings.displayName = 'Settings'

--- a/lib/assets/icons/components/SettingsOutline.tsx
+++ b/lib/assets/icons/components/SettingsOutline.tsx
@@ -44,3 +44,4 @@ const SettingsOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) =
 })
 
 export default SettingsOutline
+SettingsOutline.displayName = 'SettingsOutline'

--- a/lib/assets/icons/components/Stripe.tsx
+++ b/lib/assets/icons/components/Stripe.tsx
@@ -49,3 +49,4 @@ const Stripe = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Stripe
+Stripe.displayName = 'Stripe'

--- a/lib/assets/icons/components/Trash.tsx
+++ b/lib/assets/icons/components/Trash.tsx
@@ -40,3 +40,4 @@ const Trash = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default Trash
+Trash.displayName = 'Trash'

--- a/lib/assets/icons/components/TrashOutline.tsx
+++ b/lib/assets/icons/components/TrashOutline.tsx
@@ -40,3 +40,4 @@ const TrashOutline = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default TrashOutline
+TrashOutline.displayName = 'TrashOutline'

--- a/lib/assets/icons/components/TrendingUp.tsx
+++ b/lib/assets/icons/components/TrendingUp.tsx
@@ -40,3 +40,4 @@ const TrendingUp = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default TrendingUp
+TrendingUp.displayName = 'TrendingUp'

--- a/lib/assets/icons/components/UkFlag.tsx
+++ b/lib/assets/icons/components/UkFlag.tsx
@@ -48,3 +48,4 @@ const UkFlag = forwardRef<HTMLSpanElement, IconProps>((allProps, ref) => {
 })
 
 export default UkFlag
+UkFlag.displayName = 'UkFlag'

--- a/lib/components/atoms/Button/Button.tsx
+++ b/lib/components/atoms/Button/Button.tsx
@@ -62,3 +62,5 @@ export const Button = <T extends ElementType = 'button'>(props: ButtonProps<T>) 
 
   return <Component className={buttonClasses} {...rest} />
 }
+
+Button.displayName = 'Button'

--- a/lib/components/atoms/Separator/Separator.tsx
+++ b/lib/components/atoms/Separator/Separator.tsx
@@ -7,3 +7,5 @@ export type SeparatorProps = { className?: string }
 export const Separator = ({ className }: SeparatorProps) => {
   return <hr className={clsx(s.separator, className)} />
 }
+
+Separator.displayName = 'Separator'

--- a/lib/components/atoms/Tabs/Tabs.tsx
+++ b/lib/components/atoms/Tabs/Tabs.tsx
@@ -114,3 +114,5 @@ const TabsContent = forwardRef<HTMLDivElement, TabsContentProps>(
 )
 
 export { Tabs, TabsContent }
+Tabs.displayName = 'Tabs'
+TabsContent.displayName = 'TabsContent'

--- a/lib/components/atoms/Typography/Typography.tsx
+++ b/lib/components/atoms/Typography/Typography.tsx
@@ -55,3 +55,5 @@ export const Typography = forwardRef<HTMLParagraphElement, TypographyProps>(
     )
   }
 )
+
+Typography.displayName = 'Typography'

--- a/lib/components/molecules/Alert/Alert.tsx
+++ b/lib/components/molecules/Alert/Alert.tsx
@@ -85,3 +85,5 @@ export const Alert = (props: AlertProps): ReactElement => {
     </div>
   )
 }
+
+Alert.displayName = 'Alert'

--- a/lib/components/molecules/Select-box/Select.tsx
+++ b/lib/components/molecules/Select-box/Select.tsx
@@ -201,3 +201,4 @@ export const Select = forwardRef<ComponentRef<typeof RadixSelect.Trigger>, Selec
     )
   }
 )
+Select.displayName = 'Select'

--- a/lib/components/molecules/Toast/ToastContainer.tsx
+++ b/lib/components/molecules/Toast/ToastContainer.tsx
@@ -89,3 +89,5 @@ export const ToastContainer = (props: ToastContainerProps): React.ReactPortal | 
     document.body
   )
 }
+
+ToastContainer.displayName = 'ToastContainer'

--- a/lib/components/molecules/Toast/ToastItem.tsx
+++ b/lib/components/molecules/Toast/ToastItem.tsx
@@ -92,3 +92,4 @@ export const ToastItem = (props: ToastItemProps): ReactElement => {
     </motion.div>
   )
 }
+ToastItem.displayName = 'ToastItem'

--- a/lib/components/organisms/DatePicker/range/DatePickerRange.tsx
+++ b/lib/components/organisms/DatePicker/range/DatePickerRange.tsx
@@ -139,3 +139,5 @@ export const DatePickerRange = ({
     </DatePickerWrapper>
   )
 }
+
+DatePickerRange.displayName = 'DatePickerRange'

--- a/lib/components/organisms/DatePicker/single/DatePickerSingle.tsx
+++ b/lib/components/organisms/DatePicker/single/DatePickerSingle.tsx
@@ -133,3 +133,5 @@ export const DatePickerSingle = ({
     </DatePickerWrapper>
   )
 }
+
+DatePickerSingle.displayName = 'DatePickerSingle'

--- a/lib/components/organisms/modal/Modal.tsx
+++ b/lib/components/organisms/modal/Modal.tsx
@@ -101,3 +101,4 @@ export const Modal = ({
     </Dialog.Root>
   )
 }
+Modal.displayName = 'Modal'

--- a/lib/providers/ToastProvider/ToastProvider.tsx
+++ b/lib/providers/ToastProvider/ToastProvider.tsx
@@ -80,3 +80,5 @@ export const ToastProvider = (props: ToastProviderProps): React.ReactElement => 
     </ToastContext.Provider>
   )
 }
+
+ToastProvider.displayName = 'ToastProvider'


### PR DESCRIPTION
## 📦 What’s Added/Changed?

Added missing `displayName` definitions to components using `forwardRef` and `memo`. This improves the readability and usability of components in React DevTools by avoiding anonymous names like `ForwardRef` or `Anonymous`.

## 🧱 Type of Changes

- ♻️ Enhancement to an existing component  
- 🧰 Infrastructure / Configuration

## 🧪 Verification

- [x] Visually verified in React DevTools  
- [x] No changes to functionality or styles  
- [ ] Verified in consuming project *(if relevant)*

## 🔍 Notes for Reviewers

This change helps during development and debugging but does not affect runtime behavior. It's especially useful when inspecting components wrapped with `forwardRef`, `memo`, or HOCs.

## 🔗 Related Issues/Tickets

N/A *(or replace with issue number if applicable)*

## ✅ Pre-Merge Checklist

- [x] No changes to component logic or props  
- [x] All CI checks pass  
- [x] No temporary logs, TODOs, or commented-out code  
- [x] All discussions resolved  
- [x] 2 approvals received  
- [x] Last commit is not self-approved  

---

