### PR TITLE
Modal window update

### DIFF
--- a/lib/components/organisms/modal/Modal.module.scss
+++ b/lib/components/organisms/modal/Modal.module.scss
@@ -20,7 +20,6 @@
 
   box-sizing: border-box;
   width: 378px;
-  height: 228px;
   border: 1px solid var(--color-dark-100);
   border-radius: 2px;
 
@@ -89,6 +88,28 @@
     background-color: var(--color-dark-100);
     outline: none;
   }
+}
+
+.outsideCloseButton {
+  all: unset;
+
+  cursor: pointer;
+
+  position: absolute;
+  top: -40px;
+  right: -40px;
+
+  box-sizing: border-box;
+  width: 24px;
+  height: 24px;
+  border-radius: 100%;
+
+  font-family: inherit;
+  color: var(--color-light-100);
+
+  @include display-flex(inline-flex, center, center);
+
+
 }
 
 @keyframes overlayShow {

--- a/lib/components/organisms/modal/Modal.stories.tsx
+++ b/lib/components/organisms/modal/Modal.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import React from 'react'
 
 import { useState } from 'react'
 
@@ -17,6 +18,10 @@ const meta: Meta<typeof Modal> = {
     modalTitle: {
       control: 'text',
       description: 'Modal window title',
+    },
+    showOutsideCloseButton: {
+      control: 'boolean',
+      description: 'Show outside close button when there is no header',
     },
     className: {
       control: false,
@@ -84,6 +89,22 @@ export const Default: Story = {
   ),
   args: {
     modalTitle: 'Email sent',
+  },
+}
+
+export const WithoutHeaderOutsideClose: Story = {
+  render: args => (
+    <ModalWithState {...args}>
+      <div>
+        <Typography variant={'regular_16'} color={'light'}>
+          We have sent a link to confirm your email to <b>epam@epam.com</b>.
+        </Typography>
+      </div>
+    </ModalWithState>
+  ),
+  args: {
+    showOutsideCloseButton: true,
+    modalTitle: '',
   },
 }
 

--- a/lib/components/organisms/modal/Modal.tsx
+++ b/lib/components/organisms/modal/Modal.tsx
@@ -13,6 +13,7 @@ export type ModalProps = {
   modalTitle?: string
   width?: string | number
   height?: string | number
+  showOutsideCloseButton?: boolean
 } & ComponentPropsWithoutRef<typeof Dialog.Content>
 
 /**
@@ -52,16 +53,17 @@ export type ModalProps = {
  */
 
 export const Modal = ({
-  modalTitle,
-  onClose,
-  open,
-  children,
-  className,
-  width,
-  height,
-  style,
-  ...rest
-}: ModalProps) => {
+                        modalTitle,
+                        onClose,
+                        open,
+                        children,
+                        className,
+                        width,
+                        height,
+                        showOutsideCloseButton,
+                        style,
+                        ...rest
+                      }: ModalProps) => {
   const handleOpenChange = (isOpen: boolean) => {
     if (!isOpen) {
       onClose()
@@ -79,20 +81,25 @@ export const Modal = ({
       <Dialog.Portal>
         <Dialog.Overlay className={s.overlay} />
         <Dialog.Content className={clsx(s.content, className)} style={modalStyle} {...rest}>
-          <div className={s.header}>
-            {modalTitle && (
-              <Dialog.Title className={s.title}>
-                <Typography variant={'h1'} color={'light'}>
-                  {modalTitle}
-                </Typography>
-              </Dialog.Title>
-            )}
+          {!modalTitle && showOutsideCloseButton && (
+            <Dialog.Close asChild>
+              <button type={'button'} className={s.outsideCloseButton} aria-label={'Close'}>
+                <SvgClose svgProps={{ width: 40, height: 40 }} />
+              </button>
+            </Dialog.Close>
+          )}
+          {modalTitle && <div className={s.header}>
+            <Dialog.Title className={s.title}>
+              <Typography variant={'h1'} color={'light'}>
+                {modalTitle}
+              </Typography>
+            </Dialog.Title>
             <Dialog.Close asChild>
               <button type={'button'} className={s.iconButton} aria-label={'Close'}>
                 <SvgClose svgProps={{ width: 24, height: 24 }} />
               </button>
             </Dialog.Close>
-          </div>
+          </div>}
           <Separator />
           <div className={s.body}>{children}</div>
         </Dialog.Content>


### PR DESCRIPTION
- Added option to hide header if there is no title
- Implemented showOutsideCloseButton?: boolean in Modal and render a close “X” at the top-right corner when there’s no header and the prop is true.
- Added .outsideCloseButton styles with absolute positioning and matching hover/focus.
- Updated Storybook to expose the new control and added WithoutHeaderOutsideClose example.

<img width="549" height="237" alt="image" src="https://github.com/user-attachments/assets/5c91f213-e7db-4f31-9037-e9827d329113" />
<img width="488" height="216" alt="image" src="https://github.com/user-attachments/assets/1596dec4-2b17-4033-884d-535755ce7bb5" />
