### PR TITLE
ci(ui-kit-v2): SCRUM-161 add blocking size ci regression guard

### DIFF
--- a/.github/workflows/size-ci.yml
+++ b/.github/workflows/size-ci.yml
@@ -1,0 +1,38 @@
+name: 📏 Size CI Regression Guard
+
+on:
+  pull_request:
+    branches:
+      - 'ui-kit-v2/dev'
+  push:
+    branches:
+      - 'ui-kit-v2/dev'
+  workflow_dispatch:
+
+jobs:
+  size-ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🧾 Checkout repository
+        uses: actions/checkout@v4
+
+      - name: 🔧 Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+
+      - name: 🧩 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: 📦 Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: 🧱 Build package
+        run: pnpm run build
+
+      - name: 📏 Check package size budget
+        run: pnpm run size:ci

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "commit": "node scripts/git-commit-message.cjs",
     "generateIndex": "node scripts/generate-index.js",
     "build": "nps generateIndex && vite build && tsc",
+    "size:ci": "node scripts/size-ci-guard.mjs",
     "format": "prettier --write .",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"

--- a/scripts/size-ci-guard.mjs
+++ b/scripts/size-ci-guard.mjs
@@ -1,0 +1,87 @@
+import { execSync } from 'node:child_process'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+const BASELINE_PATH = process.env.SIZE_CI_BASELINE || 'size-ci-baseline.json'
+
+const sumBytes = (files, pattern) =>
+  files.filter(file => pattern.test(file.path)).reduce((total, file) => total + (file.size || 0), 0)
+
+const collectPackMetrics = () => {
+  const output = execSync('npm pack --dry-run --json', {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      npm_config_cache: process.env.SIZE_CI_NPM_CACHE || '.npm-cache',
+    },
+  })
+
+  const pack = JSON.parse(output)?.[0]
+
+  if (!pack || !Array.isArray(pack.files)) {
+    throw new Error('Unable to parse `npm pack --dry-run --json` output.')
+  }
+
+  const files = pack.files
+
+  return {
+    filesCount: files.length,
+    unpackedBytes: pack.unpackedSize || 0,
+    cssBytes: sumBytes(files, /\.css$/),
+    jsBytes: sumBytes(files, /\.js$/),
+    dtsBytes: sumBytes(files, /\.d\.ts$/),
+    mapBytes: sumBytes(files, /\.map$/),
+    imageBytes: sumBytes(files, /\.(png|jpe?g|webp|svg)$/i),
+  }
+}
+
+const loadBaseline = async baselinePath => {
+  const absolutePath = path.resolve(process.cwd(), baselinePath)
+  const content = await readFile(absolutePath, 'utf8')
+  const parsed = JSON.parse(content)
+
+  if (!parsed?.max || typeof parsed.max !== 'object') {
+    throw new Error(`Invalid baseline format in ${baselinePath}. Expected { "max": { ... } }.`)
+  }
+
+  return parsed.max
+}
+
+const formatDiff = (actual, max) => {
+  const delta = actual - max
+  return `${actual} > ${max} (+${delta})`
+}
+
+const main = async () => {
+  const max = await loadBaseline(BASELINE_PATH)
+  const actual = collectPackMetrics()
+
+  console.log('Size CI metrics:', JSON.stringify(actual, null, 2))
+
+  const failures = Object.entries(max).flatMap(([metric, limit]) => {
+    const actualValue = actual[metric]
+
+    if (typeof actualValue !== 'number') {
+      return [`${metric}: metric is missing in actual measurements`]
+    }
+
+    if (actualValue > limit) {
+      return [`${metric}: ${formatDiff(actualValue, limit)}`]
+    }
+
+    return []
+  })
+
+  if (failures.length > 0) {
+    console.error('\nSize CI regression detected:')
+    failures.forEach(failure => console.error(`- ${failure}`))
+    process.exit(1)
+  }
+
+  console.log('\nSize CI guard passed.')
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exit(1)
+})

--- a/size-ci-baseline.json
+++ b/size-ci-baseline.json
@@ -1,0 +1,12 @@
+{
+  "generatedAt": "2026-03-07",
+  "max": {
+    "filesCount": 229,
+    "unpackedBytes": 5193807,
+    "cssBytes": 918363,
+    "jsBytes": 285293,
+    "dtsBytes": 125323,
+    "mapBytes": 699718,
+    "imageBytes": 3157579
+  }
+}


### PR DESCRIPTION
Size CI Regression Guard implemented (SCRUM-161) on 2026-03-07.

Branch:
ui-kit-v2/phase-6-ci-release-hardening

Commit:
9fe069d — ci(ui-kit-v2): SCRUM-161 add blocking size ci regression guard

What was added:
- GitHub Actions workflow: .github/workflows/size-ci.yml
  - runs on PR/push to ui-kit-v2/dev
  - builds package and runs size guard
- size guard script: scripts/size-ci-guard.mjs
  - executes npm pack --dry-run --json
  - validates key metrics against baseline limits
  - fails CI on regression
- baseline limits file: size-ci-baseline.json
- npm script: size:ci

Local validation:
- npm run size:ci ✅

Current measured metrics:
- filesCount: 218
- unpackedBytes: 4,946,531
- cssBytes: 874,631
- jsBytes: 271,708
- dtsBytes: 119,355
- mapBytes: 666,398
- imageBytes: 3,007,218

Ready to continue with Icons Cleanup + Gate Decision (Phase 3).
