### PR TITLE
feat(ui-kit-v2): SCRUM-162 CSS/Fonts Contract (Phase 1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ npm i @ictroot/ui-kit
 ## 💡 An example of use
 
 ```tsx
+import '@ictroot/ui-kit/style.css'
+import '@ictroot/ui-kit/fonts/inter.css' // optional, opt-in
 import { Button } from '@ictroot/ui-kit'
 
 export function MyComponent() {

--- a/lib/components/organisms/DatePicker/DatePicker.module.scss
+++ b/lib/components/organisms/DatePicker/DatePicker.module.scss
@@ -1,6 +1,4 @@
 @use '@/styles/mixins' as *;
-@use '@/styles/colors' as *;
-@use '@/styles/typography' as *;
 @use '@/styles/function' as *;
 
 .container {

--- a/lib/components/organisms/modal/Modal.module.scss
+++ b/lib/components/organisms/modal/Modal.module.scss
@@ -1,6 +1,4 @@
 @use '@/styles/mixins' as *;
-@use '@/styles/colors' as *;
-@use '@/styles/typography' as *;
 @use '@/styles/function' as *;
 
 .overlay {

--- a/lib/fonts/inter.css
+++ b/lib/fonts/inter.css
@@ -1,0 +1,1 @@
+@import '@fontsource-variable/inter/index.css';

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,5 +1,3 @@
-import './styles/index.scss'
-
 export * from './assets/icons'
 export * from './components'
 export * from './providers'

--- a/lib/style.ts
+++ b/lib/style.ts
@@ -1,0 +1,3 @@
+import './styles/index.scss'
+
+export {}

--- a/lib/styles/_typography.scss
+++ b/lib/styles/_typography.scss
@@ -1,5 +1,3 @@
-@use '@fontsource-variable/inter' as *;
-
 :root {
   --font-family-primary: 'Inter Variable', sans-serif;
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,6 @@
 {
   "name": "@ictroot/ui-kit",
-
   "version": "1.0.4",
-
   "description": "Modular and expanded library of components created using Vite, Storybook and Typescript. Suitable for re-used UI elements in various projects",
   "author": "IctRoot",
   "license": "MIT",
@@ -17,14 +15,17 @@
       "import": "./dist/ui-kit.es.js",
       "require": "./dist/ui-kit.cjs.js"
     },
-    "./style.css": "./dist/ui-kit.css"
+    "./style.css": "./dist/ui-kit.css",
+    "./fonts/inter.css": "./lib/fonts/inter.css"
   },
   "files": [
     "dist",
-    "dist/*.css"
+    "dist/*.css",
+    "lib/fonts/inter.css"
   ],
   "sideEffects": [
-    "./dist/ui-kit.css"
+    "./dist/ui-kit.css",
+    "./lib/fonts/inter.css"
   ],
   "scripts": {
     "nps": "nps",
@@ -36,6 +37,9 @@
     "build": "nps generateIndex && vite build && tsc",
     "format": "prettier --write .",
     "storybook": "storybook dev -p 6006",
+    "ai:context:detect": "AI_AGENT_CONFIG_DIR=./ai-agent-config-v2 node ai-agent-config-v2/scripts/detect-project-context-registry.mjs",
+    "ai:context:ensure": "AI_AGENT_CONFIG_DIR=./ai-agent-config-v2 node ai-agent-config-v2/scripts/ensure-ai-context.mjs",
+    "ai:profiles:review": "AI_AGENT_CONFIG_DIR=./ai-agent-config-v2 node ai-agent-config-v2/scripts/review-profiles.mjs",
     "build-storybook": "storybook build"
   },
   "publishConfig": {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -12,8 +12,13 @@ import { dependencies, devDependencies, peerDependencies } from './package.json'
 export default defineConfig({
   build: {
     lib: {
-      entry: resolve(__dirname, join('lib', 'index.ts')),
-      fileName: format => `ui-kit.${format}.js`,
+      entry: {
+        index: resolve(__dirname, join('lib', 'index.ts')),
+        style: resolve(__dirname, join('lib', 'style.ts')),
+      },
+      fileName: (format, entryName) =>
+        entryName === 'index' ? `ui-kit.${format}.js` : `${entryName}.${format}.js`,
+      cssFileName: 'ui-kit',
       formats: ['es', 'cjs'],
       name: 'ui-kit',
     },


### PR DESCRIPTION
## Summary
Implements UI Kit v2 Phase 1 (CSS/Fonts Contract):
- removes hidden style side-effect from root entry
- keeps explicit style contract via @ictroot/ui-kit/style.css
- moves Inter font loading to opt-in @ictroot/ui-kit/fonts/inter.css
- removes redundant SCSS imports in modal/datepicker modules
- updates README usage docs

## Why
To enforce explicit style/font contract and reduce base CSS payload.

## Validation
- AI context ensure: OK
- npm run build: OK
- dist/ui-kit.css: 37.31 kB (gzip 6.71 kB)
- @font-face in style.css: 0
- font/woff2;base64 in style.css: 0

## Jira
SCRUM-162
