### PR TITLE
feat(ui-kit-v2): SCRUM-163 Packaging Cleanup (Phase 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
     "./style.css": "./dist/ui-kit.css"
   },
   "files": [
-    "dist",
-    "dist/*.css"
+    "dist/**/*.js",
+    "dist/**/*.d.ts",
+    "dist/**/*.css"
   ],
   "sideEffects": [
     "./dist/ui-kit.css"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,7 +6,7 @@ import { defineConfig } from 'vite'
 import dts from 'vite-plugin-dts'
 import tsconfigPaths from 'vite-tsconfig-paths'
 
-import { dependencies, devDependencies, peerDependencies } from './package.json'
+import { dependencies, peerDependencies } from './package.json'
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -22,7 +22,6 @@ export default defineConfig({
         'react/jsx-runtime',
         ...Object.keys(peerDependencies),
         ...Object.keys(dependencies),
-        ...Object.keys(devDependencies),
       ],
       output: {
         globals: {
@@ -31,6 +30,7 @@ export default defineConfig({
         },
       },
     },
+    copyPublicDir: false,
     sourcemap: true,
     target: 'esnext',
   },


### PR DESCRIPTION
## Summary
Implements UI Kit v2 Phase 2 (Packaging Cleanup):
- excludes devDependencies from rollup external
- disables copying public assets in library build (copyPublicDir: false)
- restricts npm publish files to dist js/css/d.ts (no maps/images)

## Why
To remove heavy non-runtime artifacts from publish package and prevent size regressions.

## Validation
- npm run build: OK
- npm pack --dry-run --json: compared before/after

## Pack metrics (before -> after)
- files: 223 -> 212
- unpacked size: 4,109,406 -> 1,272,899 bytes
- .map bytes: 666,583 -> 0
- dist image bytes: 3,007,218 -> 0

## Jira
SCRUM-163
