### PR TITLE
SCRUM-164: isolate icons API and remove root icon leakage

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ export function MyComponent() {
 }
 ```
 
+```tsx
+import { Search } from '@ictroot/ui-kit/icons'
+```
+
 ## 📁 components
 
 ### Components are supported at all levels of Atomic Design

--- a/lib/components/atoms/Button/Button.stories.tsx
+++ b/lib/components/atoms/Button/Button.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import { Person } from 'assets/icons'
+import Person from 'assets/icons/components/Person'
 
 import './Button.module.scss'
 

--- a/lib/components/molecules/Alert/components/CloseButton/CloseButton.tsx
+++ b/lib/components/molecules/Alert/components/CloseButton/CloseButton.tsx
@@ -1,6 +1,6 @@
 import { ComponentPropsWithoutRef, ElementRef, forwardRef } from 'react'
 
-import { Close } from 'assets/icons'
+import Close from 'assets/icons/components/Close'
 
 import styles from 'components/molecules/Alert/components/CloseButton/CloseButton.module.scss'
 

--- a/lib/components/molecules/CheckboxRadix/CheckboxIndicator.tsx
+++ b/lib/components/molecules/CheckboxRadix/CheckboxIndicator.tsx
@@ -1,7 +1,7 @@
 import { ComponentPropsWithoutRef } from 'react'
 
 import { Indicator } from '@radix-ui/react-checkbox'
-import { Checkmark } from 'assets/icons'
+import Checkmark from 'assets/icons/components/Checkmark'
 
 export const CheckboxIndicator = (props: CheckboxIndicatorProps) => {
   const { children, className, forceMount, iconSize = 18, ...rest } = props

--- a/lib/components/molecules/DropdownMenu/DropdownMenu.tsx
+++ b/lib/components/molecules/DropdownMenu/DropdownMenu.tsx
@@ -1,5 +1,5 @@
 import * as RadixDropdown from '@radix-ui/react-dropdown-menu'
-import { MoreHorizontal } from 'assets/icons'
+import MoreHorizontal from 'assets/icons/components/MoreHorizontal'
 import { Typography } from 'components/atoms'
 
 import s from './DropdownMenu.module.scss'

--- a/lib/components/molecules/Select/Select.tsx
+++ b/lib/components/molecules/Select/Select.tsx
@@ -2,7 +2,7 @@ import { type ComponentRef, forwardRef, ReactNode, useId } from 'react'
 
 import * as ScrollArea from '@radix-ui/react-scroll-area'
 import * as RadixSelect from '@radix-ui/react-select'
-import { ArrowDownSimple } from 'assets/icons'
+import ArrowDownSimple from 'assets/icons/components/ArrowDownSimple'
 import { clsx } from 'clsx'
 import { Typography } from 'components/atoms'
 

--- a/lib/components/organisms/DatePicker/components/DatePickerWrapper.tsx
+++ b/lib/components/organisms/DatePicker/components/DatePickerWrapper.tsx
@@ -1,5 +1,6 @@
 import { Popover, PopoverContent, PopoverPortal, PopoverTrigger } from '@radix-ui/react-popover'
-import { Calendar, CalendarOutline } from 'assets/icons'
+import Calendar from 'assets/icons/components/Calendar'
+import CalendarOutline from 'assets/icons/components/CalendarOutline'
 import { clsx } from 'clsx'
 import { ErrorMessage } from 'components/atoms'
 import { LabelRadix } from 'components/molecules'

--- a/lib/icons.ts
+++ b/lib/icons.ts
@@ -1,0 +1,1 @@
+export * from './assets/icons'

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,3 @@
-export * from './assets/icons'
 export * from './components'
 export * from './providers'
 export { clsx } from 'clsx'

--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
       "import": "./dist/ui-kit.es.js",
       "require": "./dist/ui-kit.cjs.js"
     },
+    "./icons": {
+      "types": "./dist/assets/icons/index.d.ts",
+      "import": "./dist/icons.es.js",
+      "require": "./dist/icons.cjs.js"
+    },
     "./style.css": "./dist/ui-kit.css",
     "./fonts/inter.css": "./lib/fonts/inter.css"
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
     lib: {
       entry: {
         index: resolve(__dirname, join('lib', 'index.ts')),
+        icons: resolve(__dirname, join('lib', 'icons.ts')),
         style: resolve(__dirname, join('lib', 'style.ts')),
       },
       fileName: (format, entryName) =>


### PR DESCRIPTION
## 📦 What’s Added/Changed?

- Removed icon exports from root API (`@ictroot/ui-kit`).
- Added dedicated icons subpath export: `@ictroot/ui-kit/icons`.
- Migrated internal icon imports to isolated component paths.
- Updated README with icons import example.
- Measured Scenario A/B/C bundle leakage and documented gate decision.

---

## 🧱 Type of Changes

- [ ] ✨ New component
- [x] ♻️ Enhancement to an existing component
- [ ] 🐛 Bug fix
- [ ] 🎨 SCSS style update/refactor
- [x] 📖 Documentation / Storybook
- [ ] 🧪 Tests (unit/visual)
- [x] 🧰 Infrastructure / Configuration

---

## 🧪 Verification

- [ ] Tests added or updated (if applicable)
- [ ] Visually checked in Storybook
- [ ] Verified in consuming project (if relevant)

Local checks performed:
- `npm run ai:context:ensure` ✅
- `npm run build` ✅

Scenario metrics (gzip):
- A: 9,921 B
- B: 29,477 B
- C: 20,890 B

Gate decision:
- Scenario A leakage is <= 15 KB, so split into `@ictroot/icons` is **not required** at this stage.

---

## 🔍 Notes for Reviewers

Please focus on:
- export contract changes (`root` vs `./icons`)
- internal icon import isolation
- backward compatibility expectations for consumer imports

---

## 🔗 Related Issues/Tickets

- SCRUM-164

---

## ✅ Pre-Merge Checklist

- [ ] Component is covered by tests (if applicable)
- [x] Docs / Storybook updated
- [ ] All CI checks pass
- [x] No temporary logs, TODOs, or commented-out code
- [ ] All discussions resolved
- [ ] 2 approvals received
- [ ] Last commit is not self-approved

---

✅ **Thank you for contributing to the UI library!**
