### PR TITLE
SCRUM-167 Phase 4: selective subpath exports for heavy modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,15 @@ export function MyComponent() {
 import { Search } from '@ictroot/ui-kit/icons'
 ```
 
+```tsx
+import { DatePickerSingle } from '@ictroot/ui-kit/datepicker'
+import { ToastContainer } from '@ictroot/ui-kit/toast'
+import { Recaptcha } from '@ictroot/ui-kit/recaptcha'
+import { Modal } from '@ictroot/ui-kit/modal'
+```
+
+Root import is still supported for DX, but subpath imports are recommended for heavy modules.
+
 ## 📁 components
 
 ### Components are supported at all levels of Atomic Design

--- a/lib/datepicker.ts
+++ b/lib/datepicker.ts
@@ -1,0 +1,1 @@
+export * from './components/organisms/DatePicker'

--- a/lib/modal.ts
+++ b/lib/modal.ts
@@ -1,0 +1,1 @@
+export * from './components/organisms/modal'

--- a/lib/recaptcha.ts
+++ b/lib/recaptcha.ts
@@ -1,0 +1,1 @@
+export * from './components/molecules/Recaptcha'

--- a/lib/toast.ts
+++ b/lib/toast.ts
@@ -1,0 +1,1 @@
+export * from './components/molecules/Toast'

--- a/package.json
+++ b/package.json
@@ -20,6 +20,26 @@
       "import": "./dist/icons.es.js",
       "require": "./dist/icons.cjs.js"
     },
+    "./datepicker": {
+      "types": "./dist/datepicker.d.ts",
+      "import": "./dist/datepicker.es.js",
+      "require": "./dist/datepicker.cjs.js"
+    },
+    "./toast": {
+      "types": "./dist/toast.d.ts",
+      "import": "./dist/toast.es.js",
+      "require": "./dist/toast.cjs.js"
+    },
+    "./recaptcha": {
+      "types": "./dist/recaptcha.d.ts",
+      "import": "./dist/recaptcha.es.js",
+      "require": "./dist/recaptcha.cjs.js"
+    },
+    "./modal": {
+      "types": "./dist/modal.d.ts",
+      "import": "./dist/modal.es.js",
+      "require": "./dist/modal.cjs.js"
+    },
     "./style.css": "./dist/ui-kit.css",
     "./fonts/inter.css": "./lib/fonts/inter.css"
   },

--- a/size-ci-baseline.json
+++ b/size-ci-baseline.json
@@ -1,7 +1,7 @@
 {
   "generatedAt": "2026-03-07",
   "max": {
-    "filesCount": 229,
+    "filesCount": 245,
     "unpackedBytes": 5193807,
     "cssBytes": 918363,
     "jsBytes": 285293,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,10 @@ export default defineConfig({
       entry: {
         index: resolve(__dirname, join('lib', 'index.ts')),
         icons: resolve(__dirname, join('lib', 'icons.ts')),
+        datepicker: resolve(__dirname, join('lib', 'datepicker.ts')),
+        toast: resolve(__dirname, join('lib', 'toast.ts')),
+        recaptcha: resolve(__dirname, join('lib', 'recaptcha.ts')),
+        modal: resolve(__dirname, join('lib', 'modal.ts')),
         style: resolve(__dirname, join('lib', 'style.ts')),
       },
       fileName: (format, entryName) =>


### PR DESCRIPTION
## 📦 What’s Added/Changed?

- Added selective subpath exports for heavy modules:
  - `@ictroot/ui-kit/datepicker`
  - `@ictroot/ui-kit/toast`
  - `@ictroot/ui-kit/recaptcha`
  - `@ictroot/ui-kit/modal`
- Added dedicated lib entrypoints for those modules in Vite build config.
- Updated `package.json` exports/types/import/require mappings.
- Updated README with subpath usage examples.
- Kept root import for DX, but documented subpath import as recommended for heavy modules.
- Updated `size-ci-baseline.json` (`filesCount`) to reflect expected new artifact count.

---

## 🧱 Type of Changes

- [ ] ✨ New component
- [x] ♻️ Enhancement to an existing component
- [ ] 🐛 Bug fix
- [ ] 🎨 SCSS style update/refactor
- [x] 📖 Documentation / Storybook
- [ ] 🧪 Tests (unit/visual)
- [x] 🧰 Infrastructure / Configuration

---

## 🧪 Verification

- [ ] Tests added or updated (if applicable)
- [ ] Visually checked in Storybook
- [ ] Verified in consuming project (if relevant)

Local checks performed:
- `npm run ai:context:ensure` ✅
- `npm run build` ✅
- `npm run size:ci` ✅

Bundle comparison (gzip, root vs subpath):
- DatePicker: `9187 -> 3203`
- Toast: `9174 -> 2288`
- Recaptcha: `9816 -> 1328`
- Modal: `9705 -> 1679`

---

## 🔍 Notes for Reviewers

Please focus on:
- correctness of new export contract in `package.json`
- Vite multi-entry build output consistency (`*.es.js`, `*.cjs.js`, `*.d.ts`)
- docs alignment for root import vs recommended subpath usage
- size-ci baseline update rationale (`filesCount` increase is expected)

---

## 🔗 Related Issues/Tickets

- SCRUM-167

---

## ✅ Pre-Merge Checklist

- [ ] Component is covered by tests (if applicable)
- [x] Docs / Storybook updated
- [ ] All CI checks pass
- [x] No temporary logs, TODOs, or commented-out code
- [ ] All discussions resolved
- [ ] 2 approvals received
- [ ] Last commit is not self-approved

---

✅ **Thank you for contributing to the UI library!**
