### PR TITLE
SCRUM-165: add blocking Next SSR smoke and keep subpath exports for h…

### DIFF
--- a/.github/workflows/ssr-smoke.yml
+++ b/.github/workflows/ssr-smoke.yml
@@ -1,0 +1,41 @@
+name: 🧪 SSR Hydration Smoke
+
+on:
+  pull_request:
+    branches:
+      - 'ui-kit-v2/dev'
+  push:
+    branches:
+      - 'ui-kit-v2/dev'
+  workflow_dispatch:
+
+jobs:
+  ssr-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: 🧾 Checkout repository
+        uses: actions/checkout@v4
+
+      - name: 🔧 Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 8
+
+      - name: 🧩 Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: 📦 Install root dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: 🧱 Build package
+        run: pnpm run build
+
+      - name: 🌐 Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: 🧪 Run SSR/hydration smoke
+        run: pnpm run ssr:smoke

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ dist
 storybook-static
 dist-ssr
 *.local
+.next
+fixtures/next-ssr-smoke/vendor
+fixtures/next-ssr-smoke/package-lock.json
 
 # Editor directories and files
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -46,10 +46,36 @@ import { Search } from '@ictroot/ui-kit/icons'
 import { DatePickerSingle } from '@ictroot/ui-kit/datepicker'
 import { ToastContainer } from '@ictroot/ui-kit/toast'
 import { Recaptcha } from '@ictroot/ui-kit/recaptcha'
-import { Modal } from '@ictroot/ui-kit/modal'
 ```
 
 Root import is still supported for DX, but subpath imports are recommended for heavy modules.
+
+Heavy-module subpaths are intentionally limited to:
+- `@ictroot/ui-kit/datepicker`
+- `@ictroot/ui-kit/toast`
+- `@ictroot/ui-kit/recaptcha`
+
+`Modal` should be imported from root:
+
+```tsx
+import { Modal } from '@ictroot/ui-kit'
+```
+
+SSR note for Next.js + Recaptcha:
+
+```tsx
+import dynamic from 'next/dynamic'
+
+const Recaptcha = dynamic(() => import('@ictroot/ui-kit/recaptcha').then(mod => mod.Recaptcha), {
+  ssr: false,
+})
+```
+
+SSR smoke gate command:
+
+```bash
+npm run ssr:smoke
+```
 
 ## 📁 components
 

--- a/fixtures/next-ssr-smoke/README.md
+++ b/fixtures/next-ssr-smoke/README.md
@@ -1,0 +1,15 @@
+# Next SSR/Hydration Smoke Fixture
+
+This fixture validates that `@ictroot/ui-kit` heavy-module subpaths do not break SSR/hydration in Next.js.
+
+Checked modules:
+- `@ictroot/ui-kit/datepicker`
+- `@ictroot/ui-kit/toast`
+- `@ictroot/ui-kit/recaptcha` (with `next/dynamic` and `ssr: false`)
+
+Run through the root script:
+
+```bash
+npm run build
+npm run ssr:smoke
+```

--- a/fixtures/next-ssr-smoke/next.config.mjs
+++ b/fixtures/next-ssr-smoke/next.config.mjs
@@ -1,0 +1,21 @@
+import path from 'node:path'
+
+const nextConfig = {
+  eslint: {
+    ignoreDuringBuilds: true,
+  },
+  transpilePackages: ['@ictroot/ui-kit'],
+  webpack: config => {
+    config.resolve.alias = {
+      ...(config.resolve.alias || {}),
+      react: path.resolve('./node_modules/react'),
+      'react-dom': path.resolve('./node_modules/react-dom'),
+      'react/jsx-runtime': path.resolve('./node_modules/react/jsx-runtime.js'),
+      'react/jsx-dev-runtime': path.resolve('./node_modules/react/jsx-dev-runtime.js'),
+    }
+
+    return config
+  },
+}
+
+export default nextConfig

--- a/fixtures/next-ssr-smoke/package.json
+++ b/fixtures/next-ssr-smoke/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "next-ssr-smoke-fixture",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "@ictroot/ui-kit": "file:./vendor/ui-kit-smoke.tgz",
+    "next": "^14.2.0",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  }
+}

--- a/fixtures/next-ssr-smoke/pages/_app.js
+++ b/fixtures/next-ssr-smoke/pages/_app.js
@@ -1,0 +1,5 @@
+import '@ictroot/ui-kit/style.css'
+
+export default function App({ Component, pageProps }) {
+  return <Component {...pageProps} />
+}

--- a/fixtures/next-ssr-smoke/pages/index.js
+++ b/fixtures/next-ssr-smoke/pages/index.js
@@ -1,0 +1,70 @@
+import dynamic from 'next/dynamic'
+import { useEffect, useMemo, useState } from 'react'
+import { DatePickerSingle } from '@ictroot/ui-kit/datepicker'
+import { ToastContainer } from '@ictroot/ui-kit/toast'
+
+const Recaptcha = dynamic(() => import('@ictroot/ui-kit/recaptcha').then(mod => mod.Recaptcha), {
+  ssr: false,
+})
+
+export default function HomePage() {
+  const [hydrationState, setHydrationState] = useState(0)
+  const [isClient, setIsClient] = useState(false)
+
+  useEffect(() => {
+    setHydrationState(1)
+    setIsClient(true)
+  }, [])
+
+  const toasts = useMemo(
+    () => [
+      {
+        id: 'ssr-smoke-toast',
+        type: 'success',
+        message: 'Toast smoke rendered',
+        duration: 3_000,
+        createdAt: Date.now(),
+      },
+    ],
+    []
+  )
+
+  return (
+    <main style={{ padding: 24 }}>
+      <h1>UI Kit SSR Smoke</h1>
+
+      <div data-testid={'datepicker-smoke'}>
+        <DatePickerSingle label={'Smoke Date'} placeholder={'Pick a date'} />
+      </div>
+
+      <div data-testid={'recaptcha-smoke'} style={{ marginTop: 24 }}>
+        <Recaptcha sitekey={'test-site-key'} />
+      </div>
+
+      <button
+        data-testid={'hydrate-action'}
+        type={'button'}
+        onClick={() => setHydrationState(value => value + 1)}
+        style={{ marginTop: 24 }}
+      >
+        Increment hydration marker
+      </button>
+      <output data-testid={'hydration-state'} style={{ marginLeft: 12 }}>
+        {`hydrated:${hydrationState}`}
+      </output>
+
+      {isClient && (
+        <ToastContainer
+          toasts={toasts}
+          position={'top-right'}
+          enableHoverPause={false}
+          enableProgressBar={false}
+          onRemove={() => {}}
+          onPause={() => {}}
+          onResume={() => {}}
+          renderToast={toast => <div data-testid={'toast-smoke'}>{toast.message}</div>}
+        />
+      )}
+    </main>
+  )
+}

--- a/lib/modal.ts
+++ b/lib/modal.ts
@@ -1,1 +1,0 @@
-export * from './components/organisms/modal'

--- a/package.json
+++ b/package.json
@@ -35,11 +35,6 @@
       "import": "./dist/recaptcha.es.js",
       "require": "./dist/recaptcha.cjs.js"
     },
-    "./modal": {
-      "types": "./dist/modal.d.ts",
-      "import": "./dist/modal.es.js",
-      "require": "./dist/modal.cjs.js"
-    },
     "./style.css": "./dist/ui-kit.css",
     "./fonts/inter.css": "./lib/fonts/inter.css"
   },
@@ -61,6 +56,7 @@
     "generateIndex": "node scripts/generate-index.js",
     "build": "nps generateIndex && vite build && tsc",
     "size:ci": "node scripts/size-ci-guard.mjs",
+    "ssr:smoke": "node scripts/ssr-hydration-smoke-next.mjs",
     "format": "prettier --write .",
     "storybook": "storybook dev -p 6006",
     "ai:context:detect": "AI_AGENT_CONFIG_DIR=./ai-agent-config-v2 node ai-agent-config-v2/scripts/detect-project-context-registry.mjs",

--- a/scripts/ssr-hydration-smoke-next.mjs
+++ b/scripts/ssr-hydration-smoke-next.mjs
@@ -1,0 +1,178 @@
+import { execFileSync, spawn } from 'node:child_process'
+import { copyFileSync, existsSync, mkdirSync, rmSync } from 'node:fs'
+import path from 'node:path'
+import process from 'node:process'
+import { chromium } from 'playwright'
+
+const ROOT_DIR = process.cwd()
+const FIXTURE_DIR = path.resolve(ROOT_DIR, 'fixtures/next-ssr-smoke')
+const FIXTURE_TARBALL_PATH = path.resolve(FIXTURE_DIR, 'vendor/ui-kit-smoke.tgz')
+const FIXTURE_URL = 'http://127.0.0.1:4010'
+const SERVER_BOOT_TIMEOUT_MS = 90_000
+const HYDRATION_ERROR_PATTERN =
+  /(hydration|did not match|text content does not match|server html|window is not defined|document is not defined)/i
+
+const wait = ms => new Promise(resolve => setTimeout(resolve, ms))
+
+const runCommand = (command, args, cwd) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd,
+      env: process.env,
+      shell: process.platform === 'win32',
+      stdio: 'inherit',
+    })
+
+    child.on('error', reject)
+    child.on('exit', code => {
+      if (code === 0) {
+        resolve()
+        return
+      }
+
+      reject(new Error(`Command failed: ${command} ${args.join(' ')}`))
+    })
+  })
+
+const waitForServer = async () => {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < SERVER_BOOT_TIMEOUT_MS) {
+    try {
+      const response = await fetch(`${FIXTURE_URL}/`)
+      if (response.ok) {
+        return
+      }
+    } catch {}
+
+    await wait(1_000)
+  }
+
+  throw new Error(`Next fixture did not start within ${SERVER_BOOT_TIMEOUT_MS}ms`)
+}
+
+const stopServer = async server => {
+  if (!server || server.exitCode !== null) {
+    return
+  }
+
+  await new Promise(resolve => {
+    const timeout = setTimeout(() => {
+      server.kill('SIGKILL')
+    }, 5_000)
+
+    server.once('exit', () => {
+      clearTimeout(timeout)
+      resolve()
+    })
+
+    server.kill('SIGTERM')
+  })
+}
+
+const prepareFixtureTarball = () => {
+  const packOutput = execFileSync('npm', ['pack', '--json'], {
+    cwd: ROOT_DIR,
+    encoding: 'utf8',
+    env: process.env,
+  })
+  const packed = JSON.parse(packOutput)?.[0]
+
+  if (!packed?.filename) {
+    throw new Error('Unable to resolve tarball filename from `npm pack --json`.')
+  }
+
+  const sourceTarballPath = path.resolve(ROOT_DIR, packed.filename)
+  mkdirSync(path.dirname(FIXTURE_TARBALL_PATH), { recursive: true })
+  rmSync(FIXTURE_TARBALL_PATH, { force: true })
+  copyFileSync(sourceTarballPath, FIXTURE_TARBALL_PATH)
+  rmSync(sourceTarballPath, { force: true })
+}
+
+const main = async () => {
+  if (!existsSync(path.resolve(ROOT_DIR, 'dist/ui-kit.es.js'))) {
+    throw new Error('Missing dist build. Run `npm run build` before `npm run ssr:smoke`.')
+  }
+
+  if (!existsSync(path.resolve(FIXTURE_DIR, 'package.json'))) {
+    throw new Error(`Missing Next fixture package at ${FIXTURE_DIR}`)
+  }
+
+  console.log('Packing local @ictroot/ui-kit for fixture...')
+  prepareFixtureTarball()
+
+  console.log('Installing Next fixture dependencies...')
+  await runCommand(
+    'npm',
+    ['install', '--no-audit', '--no-fund', '--force', '--no-package-lock'],
+    FIXTURE_DIR
+  )
+
+  console.log('Building Next fixture...')
+  await runCommand('npm', ['run', 'build'], FIXTURE_DIR)
+
+  console.log('Starting Next fixture...')
+  const server = spawn(
+    'npm',
+    ['run', 'start', '--', '--hostname', '127.0.0.1', '--port', '4010'],
+    {
+      cwd: FIXTURE_DIR,
+      env: process.env,
+      shell: process.platform === 'win32',
+      stdio: 'inherit',
+    }
+  )
+
+  const hydrationErrors = []
+  const runtimeErrors = []
+  let browser
+
+  try {
+    await waitForServer()
+
+    browser = await chromium.launch({ headless: true })
+    const page = await browser.newPage()
+
+    page.on('console', message => {
+      const text = message.text()
+      if (HYDRATION_ERROR_PATTERN.test(text)) {
+        hydrationErrors.push(text)
+      }
+    })
+
+    page.on('pageerror', error => {
+      runtimeErrors.push(error.message)
+    })
+
+    await page.goto(`${FIXTURE_URL}/`, { waitUntil: 'domcontentloaded', timeout: 30_000 })
+
+    await page.waitForSelector('[data-testid="datepicker-smoke"]', { timeout: 20_000 })
+    await page.waitForSelector('[data-testid="toast-smoke"]', { timeout: 20_000 })
+    await page.waitForSelector('.recaptcha-core', { timeout: 20_000 })
+    await page.click('[data-testid="hydrate-action"]')
+    await page.waitForFunction(
+      () => document.querySelector('[data-testid="hydration-state"]')?.textContent === 'hydrated:2',
+      { timeout: 20_000 }
+    )
+
+    if (runtimeErrors.length > 0) {
+      throw new Error(`Runtime errors detected:\n- ${runtimeErrors.join('\n- ')}`)
+    }
+
+    if (hydrationErrors.length > 0) {
+      throw new Error(`Hydration/SSR errors detected:\n- ${hydrationErrors.join('\n- ')}`)
+    }
+
+    console.log('SSR/hydration smoke passed.')
+  } finally {
+    if (browser) {
+      await browser.close()
+    }
+    await stopServer(server)
+  }
+}
+
+main().catch(error => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exit(1)
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,7 +18,6 @@ export default defineConfig({
         datepicker: resolve(__dirname, join('lib', 'datepicker.ts')),
         toast: resolve(__dirname, join('lib', 'toast.ts')),
         recaptcha: resolve(__dirname, join('lib', 'recaptcha.ts')),
-        modal: resolve(__dirname, join('lib', 'modal.ts')),
         style: resolve(__dirname, join('lib', 'style.ts')),
       },
       fileName: (format, entryName) =>


### PR DESCRIPTION
## 📦 What’s Added/Changed?
- Added blocking SSR/hydration smoke gate for Next fixture:
  - new script `npm run ssr:smoke`
  - CI workflow `.github/workflows/ssr-smoke.yml`
- Added Next fixture under `fixtures/next-ssr-smoke` to validate SSR + hydration behavior for heavy modules.
- Limited selective subpath exports to heavy modules only:
  - kept: `@ictroot/ui-kit/datepicker`, `@ictroot/ui-kit/toast`, `@ictroot/ui-kit/recaptcha`
  - removed: `@ictroot/ui-kit/modal`
- Updated import contract docs in `README.md` (Modal via root import, Recaptcha SSR note for Next.js).

---

## 🧱 Type of Changes

- [ ] ✨ New component
- [x] ♻️ Enhancement to an existing component
- [ ] 🐛 Bug fix
- [ ] 🎨 SCSS style update/refactor
- [x] 📖 Documentation / Storybook
- [ ] 🧪 Tests (unit/visual)
- [x] 🧰 Infrastructure / Configuration

---

## 🧪 Verification

- [x] `npm run build`
- [x] `npm run size:ci`
- [x] `npm run ssr:smoke`
- [x] `npm run ai:context:ensure`

---

## 🔍 Notes for Reviewers

- `SSR Hydration Smoke` workflow is intended to be marked as a required status check for `ui-kit-v2/dev`.
- `Modal` remains available via root import (`import { Modal } from '@ictroot/ui-kit'`), only dedicated subpath export was removed.

---

## 🔗 Related Issues/Tickets

- SCRUM-165

---

## ✅ Pre-Merge Checklist

- [x] Component is covered by tests (if applicable)
- [x] Docs / Storybook updated
- [x] All CI checks pass
- [x] No temporary logs, TODOs, or commented-out code
- [ ] All discussions resolved
- [ ] 2 approvals received
- [ ] Last commit is not self-approved
