### PR TITLE
SCRUM-143: Add label customization + invalid label/error states for Input, TextArea, Select

### DIFF
--- a/lib/components/molecules/CheckboxRadix/CheckboxRadix.stories.tsx
+++ b/lib/components/molecules/CheckboxRadix/CheckboxRadix.stories.tsx
@@ -1,8 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { expect, within } from '@storybook/test'
 
 import { useState } from 'react'
 
 import { CheckboxRadix } from 'components/molecules/CheckboxRadix/CheckboxRadix'
+import labelRadixStyles from 'components/molecules/LabelRadix/LabelRadix.module.scss'
 
 const meta = {
   component: CheckboxRadix,
@@ -60,6 +62,13 @@ export const Controlled: Story = {
     return (
       <CheckboxRadix {...args} checked={checked} onCheckedChange={() => setChecked(!checked)} />
     )
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const label = canvas.getByText('Terms of Service').closest('label')
+
+    await expect(label).not.toBeNull()
+    await expect(label).toHaveClass(labelRadixStyles.invalid)
   },
 }
 

--- a/lib/components/molecules/CheckboxRadix/CheckboxRadix.tsx
+++ b/lib/components/molecules/CheckboxRadix/CheckboxRadix.tsx
@@ -88,6 +88,8 @@ export const CheckboxRadix = forwardRef<ElementRef<typeof Checkbox.Root>, Checkb
           required
           label={label}
           aria-label={'Checkbox'}
+          invalid={Boolean(errorMessage)}
+          disabled={disabled}
           className={classNames.label}
           htmlFor={id}
         >

--- a/lib/components/molecules/Input/Input.module.scss
+++ b/lib/components/molecules/Input/Input.module.scss
@@ -50,14 +50,25 @@ $input-padding-with-icon: 44px;
   width: 100%;
 }
 
+.feedbackSlot {
+  min-height: var(--line-height-m);
+  margin-top: 0;
+}
+
+.feedbackPlaceholder {
+  visibility: hidden;
+  display: block;
+}
+
 .inputContainer {
   position: relative;
 
   @include flex-center;
 }
 
-.label p {
+.label {
   color: var(--color-light-900);
+  margin-bottom: 0;
 }
 
 .input {
@@ -80,7 +91,7 @@ $input-padding-with-icon: 44px;
 
   &.error:not(:disabled) {
     border-color: var(--color-danger-500);
-    color: var(--color-light-100);
+    color: var(--color-danger-500);
     outline-color: var(--color-danger-500);
   }
 }
@@ -94,7 +105,7 @@ $input-padding-with-icon: 44px;
   color: var(--color-light-900);
 
   &.error {
-    color: var(--color-light-100);
+    color: var(--color-danger-500);
   }
 
   & + input {
@@ -128,7 +139,7 @@ $input-padding-with-icon: 44px;
 .disabled {
   .eyeButton,
   .searchIcon,
-  .label p {
+  .label {
     cursor: not-allowed;
     color: var(--color-dark-100);
   }

--- a/lib/components/molecules/Input/Input.stories.tsx
+++ b/lib/components/molecules/Input/Input.stories.tsx
@@ -1,4 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { expect, userEvent, within } from '@storybook/test'
+
+import { useState } from 'react'
+
+import labelRadixStyles from 'components/molecules/LabelRadix/LabelRadix.module.scss'
 
 import { Input } from './Input'
 
@@ -11,7 +16,10 @@ const meta: Meta<typeof Input> = {
   },
   argTypes: {
     label: { control: 'text' },
+    labelClassName: { control: 'text' },
+    feedbackSlotClassName: { control: 'text' },
     error: { control: 'text' },
+    reserveErrorSpace: { control: 'boolean' },
     placeholder: { control: 'text' },
     disabled: { control: 'boolean' },
   },
@@ -56,6 +64,30 @@ export const Error: Story = {
     label: 'Password',
     placeholder: 'Enter password',
     error: 'Error text',
+    defaultValue: 'Wrong value',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const label = canvas.getByText('Password').closest('label')
+
+    await expect(label).not.toBeNull()
+    await expect(label).toHaveClass(labelRadixStyles.invalid)
+  },
+}
+
+export const CustomLabelClass: Story = {
+  args: {
+    label: 'Email',
+    id: 'custom-label-input',
+    placeholder: 'Enter your email',
+    labelClassName: 'custom-input-label',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const label = canvas.getByText('Email').closest('label')
+
+    await expect(label).not.toBeNull()
+    await expect(label).toHaveClass('custom-input-label')
   },
 }
 
@@ -64,5 +96,121 @@ export const Disabled: Story = {
     label: 'Disabled Input',
     placeholder: 'You cannot type here',
     disabled: true,
+  },
+}
+
+export const ReservedErrorSpace: Story = {
+  render: args => {
+    const [showFirstError, setShowFirstError] = useState(false)
+    const [showSecondError, setShowSecondError] = useState(false)
+
+    return (
+      <div style={{ width: '320px', display: 'flex', flexDirection: 'column', gap: '12px' }}>
+        <button type={'button'} onClick={() => setShowFirstError(prev => !prev)}>
+          Toggle first error
+        </button>
+        <button type={'button'} onClick={() => setShowSecondError(prev => !prev)}>
+          Toggle second error
+        </button>
+        <Input
+          {...args}
+          id={'reserved-space-first'}
+          label={'First name'}
+          placeholder={'Enter first name'}
+          reserveErrorSpace
+          error={showFirstError ? 'First name is required' : undefined}
+        />
+        <Input
+          id={'reserved-space-second'}
+          label={'Second name'}
+          placeholder={'Enter second name'}
+          reserveErrorSpace
+          error={showSecondError ? 'Second name is required' : undefined}
+        />
+        <div style={{ border: '1px dashed var(--color-dark-100)', padding: '8px' }}>
+          Block below should not jump
+        </div>
+      </div>
+    )
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const firstToggle = canvas.getByRole('button', { name: 'Toggle first error' })
+    const secondToggle = canvas.getByRole('button', { name: 'Toggle second error' })
+    const secondInput = canvas.getByLabelText('Second name')
+    const topBefore = secondInput.getBoundingClientRect().top
+
+    await userEvent.click(firstToggle)
+    await userEvent.click(secondToggle)
+
+    await expect(canvas.getByText('First name is required')).toBeInTheDocument()
+    await expect(canvas.getByText('Second name is required')).toBeInTheDocument()
+
+    const topAfter = secondInput.getBoundingClientRect().top
+
+    await expect(Math.round(topAfter)).toBe(Math.round(topBefore))
+  },
+}
+
+export const ReservedErrorSpaceCompact: Story = {
+  render: args => {
+    const [showFirstError, setShowFirstError] = useState(false)
+    const [showSecondError, setShowSecondError] = useState(false)
+
+    return (
+      <div style={{ width: '320px', display: 'flex', flexDirection: 'column', gap: '8px' }}>
+        <style>
+          {`
+            .compact-feedback-slot {
+              min-height: 14px;
+              margin-top: 0;
+            }
+          `}
+        </style>
+        <button type={'button'} onClick={() => setShowFirstError(prev => !prev)}>
+          Toggle compact error
+        </button>
+        <button type={'button'} onClick={() => setShowSecondError(prev => !prev)}>
+          Toggle compact second error
+        </button>
+        <Input
+          {...args}
+          id={'compact-space-first'}
+          label={'Compact first name'}
+          placeholder={'Enter first name'}
+          reserveErrorSpace
+          feedbackSlotClassName={'compact-feedback-slot'}
+          error={showFirstError ? 'First name is required' : undefined}
+        />
+        <Input
+          id={'compact-space-second'}
+          label={'Compact second name'}
+          placeholder={'Enter second name'}
+          reserveErrorSpace
+          feedbackSlotClassName={'compact-feedback-slot'}
+          error={showSecondError ? 'Second name is required' : undefined}
+        />
+        <div style={{ border: '1px dashed var(--color-dark-100)', padding: '8px' }}>
+          Compact block below should not jump
+        </div>
+      </div>
+    )
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const firstToggle = canvas.getByRole('button', { name: 'Toggle compact error' })
+    const secondToggle = canvas.getByRole('button', { name: 'Toggle compact second error' })
+    const secondInput = canvas.getByLabelText('Compact second name')
+    const topBefore = secondInput.getBoundingClientRect().top
+
+    await userEvent.click(firstToggle)
+    await userEvent.click(secondToggle)
+
+    await expect(canvas.getByText('First name is required')).toBeInTheDocument()
+    await expect(canvas.getByText('Second name is required')).toBeInTheDocument()
+
+    const topAfter = secondInput.getBoundingClientRect().top
+
+    await expect(Math.round(topAfter)).toBe(Math.round(topBefore))
   },
 }

--- a/lib/components/molecules/Input/Input.tsx
+++ b/lib/components/molecules/Input/Input.tsx
@@ -11,7 +11,10 @@ import s from 'components/molecules/Input/Input.module.scss'
 
 export interface InputProps extends ComponentPropsWithoutRef<'input'> {
   label?: string
+  labelClassName?: string
+  feedbackSlotClassName?: string
   error?: string
+  reserveErrorSpace?: boolean
   placeholder?: string
   inputType?: 'text' | 'hide-able' | 'search'
   disabled?: boolean
@@ -42,7 +45,10 @@ export interface InputProps extends ComponentPropsWithoutRef<'input'> {
  * - @param props.onChange - The change event handler for the input field
  * - @param props.placeholder - The placeholder text for the input field
  * - @param props.label - The label for the input field
+ * - @param props.labelClassName - Optional className for label customization
+ * - @param props.feedbackSlotClassName - Optional className for the feedback slot (error/hint reserved space)
  * - @param props.error - The error message to display
+ * - @param props.reserveErrorSpace - Whether to reserve vertical space for the error message to prevent layout shift
  * - @param props.inputType - The type of input field to render
  * - @param props.disabled - Whether the input field is disabled
  * - @param props.required - Whether the input field is required
@@ -60,9 +66,12 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
   (
     {
       label,
+      labelClassName,
+      feedbackSlotClassName,
       value,
       onChange,
       error,
+      reserveErrorSpace,
       inputType,
       className,
       placeholder,
@@ -87,6 +96,8 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     const generatedId = useId()
 
     const inputId = id ?? generatedId
+    const errorMessageId = `${inputId}-error`
+    const shouldRenderFeedback = Boolean(error) || reserveErrorSpace
 
     return (
       <div className={clsx(s.inputWrapper, disabled && s.disabled)}>
@@ -97,7 +108,8 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             typographyVariant={'regular_14'}
             required={required}
             disabled={disabled}
-            className={clsx(s.label)}
+            invalid={Boolean(error)}
+            className={clsx(s.label, labelClassName)}
           />
         )}
         <Typography variant={'regular_16'} asChild>
@@ -118,7 +130,7 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
               required={required}
               aria-required={required}
               aria-invalid={!!error}
-              aria-describedby={error ? `${id}-error` : undefined}
+              aria-describedby={error ? errorMessageId : undefined}
               onChange={onChange}
               {...props}
             />
@@ -135,7 +147,20 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             )}
           </div>
         </Typography>
-        {error && <ErrorMessage message={error} variant={'danger'} />}
+        {shouldRenderFeedback && (
+          <div
+            id={error ? errorMessageId : undefined}
+            className={clsx(s.feedbackSlot, feedbackSlotClassName)}
+          >
+            {error ? (
+              <ErrorMessage message={error} variant={'danger'} />
+            ) : (
+              <span className={s.feedbackPlaceholder} aria-hidden={'true'}>
+                &nbsp;
+              </span>
+            )}
+          </div>
+        )}
       </div>
     )
   }

--- a/lib/components/molecules/LabelRadix/LabelRadix.module.scss
+++ b/lib/components/molecules/LabelRadix/LabelRadix.module.scss
@@ -16,4 +16,25 @@
   color: currentcolor;
 
   @include mixins.display-flex(flex, center, $gap: 8px);
+
+  &.invalid {
+    color: var(--color-danger-500);
+  }
+
+  &.disabled {
+    cursor: not-allowed;
+    color: var(--color-dark-100);
+  }
+
+  &.disabled.invalid {
+    color: var(--color-dark-100);
+  }
+}
+
+.invalid {
+  color: inherit;
+}
+
+.disabled {
+  color: inherit;
 }

--- a/lib/components/molecules/LabelRadix/LabelRadix.tsx
+++ b/lib/components/molecules/LabelRadix/LabelRadix.tsx
@@ -8,6 +8,7 @@ import styles from './LabelRadix.module.scss'
 
 export interface LabelRadixProps extends ComponentPropsWithoutRef<typeof Label> {
   disabled?: boolean
+  invalid?: boolean
   children?: ReactNode
   label?: ReactNode
   required?: boolean
@@ -48,6 +49,7 @@ export interface LabelRadixProps extends ComponentPropsWithoutRef<typeof Label> 
  * @param props.children - Optional child nodes, typically form inputs; not used for the label text
  * @param props.required - Whether the associated field is required (adds `aria-required` and `*`)
  * @param props.disabled - Whether the label is for a disabled input (adds `aria-disabled`)
+ * @param props.invalid - Whether the label should be styled as invalid/error
  * @param props.typographyVariant - Typography variant for the label text (e.g. `'regular_14'`); defaults to `'regular_14'`
  * @param props.htmlFor - Associates the label with a form element via its `id`
  * @param props.className - Additional CSS class names
@@ -61,6 +63,7 @@ export const LabelRadix = (props: LabelRadixProps): ReactElement => {
     typographyVariant = 'regular_14',
     htmlFor,
     disabled,
+    invalid,
     required,
     children,
     label,
@@ -80,7 +83,7 @@ export const LabelRadix = (props: LabelRadixProps): ReactElement => {
       aria-required={required}
       id={id}
       aria-disabled={disabled}
-      className={clsx(styles.label, className)}
+      className={clsx(styles.label, invalid && styles.invalid, disabled && styles.disabled, className)}
       htmlFor={htmlFor}
       {...rest}
     >

--- a/lib/components/molecules/Select/Select.module.scss
+++ b/lib/components/molecules/Select/Select.module.scss
@@ -65,6 +65,26 @@
   }
 }
 
+.triggerError {
+  border-color: var(--color-danger-500);
+  color: var(--color-danger-500);
+
+  &:not([data-disabled]):hover {
+    border-color: var(--color-danger-500);
+    color: var(--color-danger-500);
+  }
+
+  &:not([data-disabled]):focus-visible {
+    border-color: transparent;
+    outline: 2px solid var(--color-danger-500);
+  }
+
+  &[data-state='open'] {
+    border-color: var(--color-danger-500);
+    color: var(--color-danger-500);
+  }
+}
+
 .content {
   z-index: 101;
   cursor: pointer;

--- a/lib/components/molecules/Select/Select.stories.tsx
+++ b/lib/components/molecules/Select/Select.stories.tsx
@@ -1,7 +1,11 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { expect, within } from '@storybook/test'
+
+import labelRadixStyles from 'components/molecules/LabelRadix/LabelRadix.module.scss'
 
 import { RussiaFlag, UkFlag } from '../../../assets/icons'
 import { Select } from './Select'
+import styles from './Select.module.scss'
 
 const meta: Meta<typeof Select> = {
   title: 'Components/Select',
@@ -12,6 +16,9 @@ const meta: Meta<typeof Select> = {
       control: { type: 'object' },
     },
     disabled: { control: 'boolean' },
+    classNames: {
+      control: { type: 'object' },
+    },
   },
   args: {
     defaultValue: 'React',
@@ -85,4 +92,46 @@ export const SmallSize: Story = {
       </div>
     ),
   ],
+}
+
+export const CustomLabelClass: Story = {
+  args: {
+    label: 'Language Select Label',
+    defaultValue: 'React',
+    classNames: {
+      label: 'custom-select-label',
+    },
+    items: baseItems,
+  },
+  render: args => (
+    <div>
+      <style>{`.custom-select-label { color: var(--color-danger-500); }`}</style>
+      <Select {...args} />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const label = canvas.getByText('Language Select Label').closest('label')
+
+    await expect(label).not.toBeNull()
+    await expect(label).toHaveClass('custom-select-label')
+  },
+}
+
+export const Error: Story = {
+  args: {
+    label: 'Select-box',
+    error: 'This field is required',
+    items: baseItems,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const label = canvas.getByText('Select-box').closest('label')
+    const trigger = canvas.getByLabelText('Select-box')
+
+    await expect(label).not.toBeNull()
+    await expect(label).toHaveClass(labelRadixStyles.invalid)
+    await expect(trigger).toHaveClass(styles.triggerError)
+    await expect(canvas.getByText('This field is required')).toBeInTheDocument()
+  },
 }

--- a/lib/components/molecules/Select/Select.tsx
+++ b/lib/components/molecules/Select/Select.tsx
@@ -4,7 +4,7 @@ import * as ScrollArea from '@radix-ui/react-scroll-area'
 import * as RadixSelect from '@radix-ui/react-select'
 import ArrowDownSimple from 'assets/icons/components/ArrowDownSimple'
 import { clsx } from 'clsx'
-import { Typography } from 'components/atoms'
+import { ErrorMessage, Typography } from 'components/atoms'
 
 import s from './Select.module.scss'
 
@@ -19,6 +19,7 @@ export type SelectItemsProps = {
 export type SelectProps = {
   id?: string
   label?: string
+  error?: string
   items: SelectItemsProps[]
   placeholder?: string
   size?: 'medium' | 'small'
@@ -29,6 +30,7 @@ export type SelectProps = {
   collisionPadding?: number | Partial<Record<'top' | 'right' | 'bottom' | 'left', number>>
   avoidCollisions?: boolean
   classNames?: {
+    label?: string
     trigger?: string
     content?: string
     item?: string
@@ -42,6 +44,7 @@ export type SelectProps = {
  * ## Features:
  * - Accessible select dropdown menu
  * - Optional label with automatic id association
+ * - Error state with message rendering
  * - Supports icons in options
  * - Controlled and uncontrolled value handling
  * - Customizable size via 'size' prop affecting padding, font sizes, and arrow icon size
@@ -66,6 +69,7 @@ export type SelectProps = {
  * - `props.items` - Array of select options (`{ value: string, label?: string, icon?: ReactNode }`)
  * - `props.label` - Optional label displayed above the select
  * - `props.placeholder` - Placeholder text when no value is selected
+ * - `props.error` - Optional error message displayed below the select
  * - `props.value` - The controlled value of the select. Should be used in conjunction with `onValueChange` to manage the component's state.
  * - `props.defaultValue` - The initial value for an uncontrolled select. The component manages its own state internally.
  * - `props.disabled` - Whether the select is disabled
@@ -73,7 +77,7 @@ export type SelectProps = {
  * - `props.id` - Optional id for the select trigger
  * - `props.size` - Determines the size of the select component, affecting padding, font size, and icon size. Available options are 'medium' or 'small'.
  * - `props.collisionPadding` - The padding between the content and the viewport edge. Can be a single number or a partial object of paddings. Defaults to `20`.
- * - `props.classNames` - An object of custom class names for the component's parts, allowing for targeted style overrides. Can include `trigger`, `content`, and `item`.
+ * - `props.classNames` - An object of custom class names for the component's parts, allowing for targeted style overrides. Can include `label`, `trigger`, `content`, and `item`.
  *
  * ### Returns
  * - A fully styled and accessible select dropdown component
@@ -85,6 +89,7 @@ export const Select = forwardRef<ComponentRef<typeof RadixSelect.Trigger>, Selec
       defaultValue,
       value,
       label,
+      error,
       disabled,
       items,
       size = 'medium',
@@ -105,7 +110,8 @@ export const Select = forwardRef<ComponentRef<typeof RadixSelect.Trigger>, Selec
           <LabelRadix
             htmlFor={id}
             label={label}
-            className={s.label}
+            className={clsx(s.label, classNames.label)}
+            invalid={Boolean(error)}
             typographyVariant={'regular_14'}
           />
         )}
@@ -118,7 +124,13 @@ export const Select = forwardRef<ComponentRef<typeof RadixSelect.Trigger>, Selec
           <RadixSelect.Trigger
             id={id}
             ref={ref}
-            className={clsx(s.trigger, classNames.trigger, s[`trigger--${size}`])}
+            className={clsx(
+              s.trigger,
+              error && s.triggerError,
+              classNames.trigger,
+              s[`trigger--${size}`]
+            )}
+            aria-invalid={Boolean(error)}
             {...rest}
           >
             <RadixSelect.Value placeholder={placeholder} />
@@ -163,6 +175,7 @@ export const Select = forwardRef<ComponentRef<typeof RadixSelect.Trigger>, Selec
             </RadixSelect.Content>
           </RadixSelect.Portal>
         </RadixSelect.Root>
+        {error && <ErrorMessage message={error} variant={'danger'} />}
       </div>
     )
   }

--- a/lib/components/molecules/TextArea/TextArea.module.scss
+++ b/lib/components/molecules/TextArea/TextArea.module.scss
@@ -57,12 +57,12 @@ $transition-duration: 0.2s;
   width: 100%;
 }
 
-.label p {
+.label {
   color: var(--color-light-900);
 }
 
 .disabled {
-  .label p {
+  .label {
     color: var(--color-dark-100);
   }
 }
@@ -79,7 +79,7 @@ $transition-duration: 0.2s;
 
   &.error {
     border-color: var(--color-danger-500);
-    color: var(--color-light-100);
+    color: var(--color-danger-500);
 
     &:focus {
       border-color: var(--color-danger-500);

--- a/lib/components/molecules/TextArea/TextArea.stories.tsx
+++ b/lib/components/molecules/TextArea/TextArea.stories.tsx
@@ -1,4 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { expect, within } from '@storybook/test'
+
+import labelRadixStyles from 'components/molecules/LabelRadix/LabelRadix.module.scss'
 
 import { TextArea } from './TextArea'
 
@@ -27,6 +30,29 @@ export const Error: Story = {
     error: 'Error text',
     label: 'Error',
     id: 'error',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const label = canvas.getByText('Error').closest('label')
+
+    await expect(label).not.toBeNull()
+    await expect(label).toHaveClass(labelRadixStyles.invalid)
+  },
+}
+
+export const CustomLabelClass: Story = {
+  args: {
+    label: 'Comment',
+    id: 'custom-label-textarea',
+    placeholder: 'Type your comment...',
+    labelClassName: 'custom-textarea-label',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const label = canvas.getByText('Comment').closest('label')
+
+    await expect(label).not.toBeNull()
+    await expect(label).toHaveClass('custom-textarea-label')
   },
 }
 

--- a/lib/components/molecules/TextArea/TextArea.tsx
+++ b/lib/components/molecules/TextArea/TextArea.tsx
@@ -14,6 +14,7 @@ export type DefaultTextAreaPropsType = DetailedHTMLProps<
 export interface TextAreaProps extends DefaultTextAreaPropsType {
   error?: string
   label?: string
+  labelClassName?: string
   placeholder?: string
   disabled?: boolean
   required?: boolean
@@ -61,6 +62,7 @@ export interface TextAreaProps extends DefaultTextAreaPropsType {
  *
  * - @param props - Props for the `TextArea` component
  * - @param props.label - The label for the textarea field
+ * - @param props.labelClassName - Optional className for label customization
  * - @param props.error - The error message to display
  * - @param props.placeholder - The placeholder text for the textarea field
  * - @param props.disabled - Whether the textarea field is disabled
@@ -77,7 +79,19 @@ export interface TextAreaProps extends DefaultTextAreaPropsType {
 
 export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
   (
-    { className, error, label, disabled, placeholder, required, value, onChange, id, ...restProps },
+    {
+      className,
+      error,
+      label,
+      labelClassName,
+      disabled,
+      placeholder,
+      required,
+      value,
+      onChange,
+      id,
+      ...restProps
+    },
     ref
   ) => {
     return (
@@ -89,7 +103,8 @@ export const TextArea = forwardRef<HTMLTextAreaElement, TextAreaProps>(
             typographyVariant={'regular_14'}
             required={required}
             disabled={disabled}
-            className={clsx(s.label, disabled && s.disabled)}
+            invalid={Boolean(error)}
+            className={clsx(s.label, labelClassName)}
           />
         )}
         <textarea

--- a/lib/components/organisms/DatePicker/DatePickerRange.stories.tsx
+++ b/lib/components/organisms/DatePicker/DatePickerRange.stories.tsx
@@ -1,4 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { expect, within } from '@storybook/test'
+
+import labelRadixStyles from 'components/molecules/LabelRadix/LabelRadix.module.scss'
 
 import { DatePickerRange, type DatePickerRangeProps } from './components'
 
@@ -37,6 +40,13 @@ export const WithDefaultDate: Story = {
 export const WithError: Story = {
   args: {
     error: 'Please select a date range.',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const label = canvas.getByText('Vacation Dates').closest('label')
+
+    await expect(label).not.toBeNull()
+    await expect(label).toHaveClass(labelRadixStyles.invalid)
   },
 }
 

--- a/lib/components/organisms/DatePicker/DatePickerSingle.stories.tsx
+++ b/lib/components/organisms/DatePicker/DatePickerSingle.stories.tsx
@@ -1,8 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { expect, within } from '@storybook/test'
 
 import { useState } from 'react'
 
 import { Typography } from 'components/atoms'
+import labelRadixStyles from 'components/molecules/LabelRadix/LabelRadix.module.scss'
 
 import { DatePickerSingle, type DatePickerSingleProps } from './components'
 
@@ -32,6 +34,13 @@ export const WithDefaultValue: Story = {
 export const WithError: Story = {
   args: {
     error: 'Date is required',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const label = canvas.getByText('Date of birth').closest('label')
+
+    await expect(label).not.toBeNull()
+    await expect(label).toHaveClass(labelRadixStyles.invalid)
   },
 }
 

--- a/lib/components/organisms/DatePicker/components/DatePickerWrapper.tsx
+++ b/lib/components/organisms/DatePicker/components/DatePickerWrapper.tsx
@@ -79,6 +79,7 @@ export const DatePickerWrapper: React.FC<DatePickerWrapperProps> = ({
         <LabelRadix
           htmlFor={buttonId}
           required={required}
+          invalid={Boolean(error)}
           className={clsx(s.label, classNames?.label)}
           disabled={disabled}
           data-label-for-datepicker={'true'}


### PR DESCRIPTION
## 📦 What’s Added/Changed?

- Added centralized invalid label state in `LabelRadix` (`invalid?: boolean`) with disabled priority over invalid.
- Added local label styling API:
  - `Input`: `labelClassName?: string`
  - `TextArea`: `labelClassName?: string`
  - `Select`: `classNames.label?: string`
- Added/updated error behavior in form components:
  - `Input`, `TextArea`, `DatePickerWrapper`, `CheckboxRadix` now pass invalid state to `LabelRadix`.
  - `Select` now supports `error?: string`, applies error UI to trigger/label, and renders `ErrorMessage`.
- Improved error visuals:
  - `Input`, `TextArea`, `Select` value text becomes red in error state.
- Added Storybook scenarios/tests for:
  - custom label class application
  - invalid label class on error
  - select error rendering
  - reserved error space behavior in Input stories

---

## 🧱 Type of Changes

- [ ] ✨ New component
- [x] ♻️ Enhancement to an existing component
- [x] 🐛 Bug fix
- [x] 🎨 SCSS style update/refactor
- [x] 📖 Documentation / Storybook
- [x] 🧪 Tests (unit/visual)
- [ ] 🧰 Infrastructure / Configuration

---

## 🧪 Verification

- [x] Tests added or updated (if applicable)
- [x] Visually checked in Storybook
- [ ] Verified in consuming project (if relevant)

---

## 🔍 Notes for Reviewers

- Please focus on API compatibility (`Input`/`TextArea`/`Select`) and `LabelRadix` invalid/disabled priority.
- `Select` error API was added in this PR to close the validation gap consistently.

---

## 🔗 Related Issues/Tickets

- SCRUM-143

---

## ✅ Pre-Merge Checklist

- [x] Component is covered by tests (if applicable)
- [x] Docs / Storybook updated
- [x] All CI checks pass
- [x] No temporary logs, TODOs, or commented-out code
- [ ] All discussions resolved
- [ ] 2 approvals received
- [x] Last commit is not self-approved
