### PR TITLE
SCRUM-142 fix(datepicker): stabilize controlled resets for single and range

### DIFF
--- a/lib/components/organisms/DatePicker/DatePickerRange.stories.tsx
+++ b/lib/components/organisms/DatePicker/DatePickerRange.stories.tsx
@@ -1,5 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { expect, within } from '@storybook/test'
+
+import { useState } from 'react'
+
+import { expect, userEvent, within } from '@storybook/test'
 
 import labelRadixStyles from 'components/molecules/LabelRadix/LabelRadix.module.scss'
 
@@ -69,5 +72,45 @@ export const Disabled: Story = {
         return date
       })(),
     },
+  },
+}
+
+export const ControlledReset: Story = {
+  render: (args: DatePickerRangeProps) => {
+    const [range, setRange] = useState<DatePickerRangeProps['value']>(undefined)
+
+    return (
+      <div style={{ display: 'grid', gap: 8 }}>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button
+            data-testid={'set-range'}
+            type={'button'}
+            onClick={() => setRange({ from: new Date('2011-12-12'), to: new Date('2011-12-15') })}
+          >
+            Set range
+          </button>
+          <button data-testid={'clear-range'} type={'button'} onClick={() => setRange(undefined)}>
+            Clear range
+          </button>
+        </div>
+        <DatePickerRange
+          {...args}
+          value={range}
+          defaultDate={{ from: new Date('2010-10-10'), to: new Date('2010-10-12') }}
+          onDateChange={setRange}
+        />
+      </div>
+    )
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(canvas.getByText('Select date range')).toBeInTheDocument()
+
+    await userEvent.click(canvas.getByTestId('set-range'))
+    await expect(canvas.getByText('12/12/2011 - 15/12/2011')).toBeInTheDocument()
+
+    await userEvent.click(canvas.getByTestId('clear-range'))
+    await expect(canvas.getByText('Select date range')).toBeInTheDocument()
   },
 }

--- a/lib/components/organisms/DatePicker/DatePickerSingle.stories.tsx
+++ b/lib/components/organisms/DatePicker/DatePickerSingle.stories.tsx
@@ -1,9 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react'
-import { expect, within } from '@storybook/test'
 
-import { useState } from 'react'
+import { type ReactNode, useState } from 'react'
 
+import { expect, userEvent, within } from '@storybook/test'
 import { Typography } from 'components/atoms'
+
 import labelRadixStyles from 'components/molecules/LabelRadix/LabelRadix.module.scss'
 
 import { DatePickerSingle, type DatePickerSingleProps } from './components'
@@ -67,6 +68,46 @@ export const Disabled: Story = {
   },
 }
 
+export const ControlledReset: Story = {
+  render: (args: DatePickerSingleProps) => {
+    const [date, setDate] = useState<Date | undefined>(undefined)
+
+    return (
+      <div style={{ display: 'grid', gap: 8 }}>
+        <div style={{ display: 'flex', gap: 8 }}>
+          <button
+            data-testid={'set-date'}
+            type={'button'}
+            onClick={() => setDate(new Date('2011-12-12'))}
+          >
+            Set date
+          </button>
+          <button data-testid={'clear-date'} type={'button'} onClick={() => setDate(undefined)}>
+            Clear date
+          </button>
+        </div>
+        <DatePickerSingle
+          {...args}
+          value={date}
+          defaultDate={new Date('2010-10-10')}
+          onDateChange={setDate}
+        />
+      </div>
+    )
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+
+    await expect(canvas.getByText('Select your date')).toBeInTheDocument()
+
+    await userEvent.click(canvas.getByTestId('set-date'))
+    await expect(canvas.getByText('12/12/2011')).toBeInTheDocument()
+
+    await userEvent.click(canvas.getByTestId('clear-date'))
+    await expect(canvas.getByText('Select your date')).toBeInTheDocument()
+  },
+}
+
 export const WithAgeValidation: Story = {
   render: (args: DatePickerSingleProps) => {
     const link = (
@@ -80,7 +121,7 @@ export const WithAgeValidation: Story = {
       </Typography>
     )
     const [date, setDate] = useState<Date | undefined>(new Date('2011-12-12'))
-    const [error, setError] = useState<string | React.ReactNode | undefined>(privacyPolicyMessage)
+    const [error, setError] = useState<string | ReactNode | undefined>(privacyPolicyMessage)
 
     const handleDateChange = (selectedDate: Date | undefined) => {
       setDate(selectedDate)

--- a/lib/components/organisms/DatePicker/components/DatePickerRange.tsx
+++ b/lib/components/organisms/DatePicker/components/DatePickerRange.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes, ReactElement, ReactNode, useState } from 'react'
+import { HTMLAttributes, ReactElement, ReactNode, useRef, useState } from 'react'
 import { type DateRange, DayPicker, type DayPickerProps } from 'react-day-picker'
 
 import 'react-day-picker/style.css'
@@ -74,21 +74,23 @@ export type DatePickerRangeProps = {
  * ### Returns
  * - A complete range date picker component with a trigger and a calendar popover.
  */
-export const DatePickerRange = ({
-  value,
-  defaultDate,
-  onDateChange,
-  label = 'Select Date Range',
-  placeholder = 'Select date range',
-  disabled = false,
-  required = false,
-  classNames,
-  error,
-  hint,
-  calendarProps,
-  ...restProps
-}: DatePickerRangeProps): ReactElement => {
-  const isControlled = value !== undefined
+export const DatePickerRange = (props: DatePickerRangeProps): ReactElement => {
+  const {
+    value,
+    defaultDate,
+    onDateChange,
+    label = 'Select Date Range',
+    placeholder = 'Select date range',
+    disabled = false,
+    required = false,
+    classNames,
+    error,
+    hint,
+    calendarProps,
+    ...restProps
+  } = props
+  const isControlledRef = useRef(Object.prototype.hasOwnProperty.call(props, 'value'))
+  const isControlled = isControlledRef.current
   const [internalDates, setInternalDates] = useState<DateRange>(
     defaultDate || { from: undefined, to: undefined }
   )

--- a/lib/components/organisms/DatePicker/components/DatePickerSingle.tsx
+++ b/lib/components/organisms/DatePicker/components/DatePickerSingle.tsx
@@ -1,4 +1,4 @@
-import { HTMLAttributes, ReactElement, ReactNode, useState } from 'react'
+import { HTMLAttributes, ReactElement, ReactNode, useRef, useState } from 'react'
 import { DayPicker, type DayPickerProps } from 'react-day-picker'
 
 import 'react-day-picker/style.css'
@@ -74,21 +74,23 @@ export type DatePickerSingleProps = {
  * ### Returns
  * - A complete single date picker component with a trigger and a calendar popover.
  */
-export const DatePickerSingle = ({
-  value,
-  defaultDate,
-  onDateChange,
-  label = 'Select Date',
-  placeholder = 'Select date',
-  disabled = false,
-  required = false,
-  classNames,
-  error,
-  hint,
-  calendarProps,
-  ...restProps
-}: DatePickerSingleProps): ReactElement => {
-  const isControlled = value !== undefined
+export const DatePickerSingle = (props: DatePickerSingleProps): ReactElement => {
+  const {
+    value,
+    defaultDate,
+    onDateChange,
+    label = 'Select Date',
+    placeholder = 'Select date',
+    disabled = false,
+    required = false,
+    classNames,
+    error,
+    hint,
+    calendarProps,
+    ...restProps
+  } = props
+  const isControlledRef = useRef(Object.prototype.hasOwnProperty.call(props, 'value'))
+  const isControlled = isControlledRef.current
   const [internalDate, setInternalDate] = useState<Date | undefined>(defaultDate)
   const selectedDate = isControlled ? value : internalDate
 


### PR DESCRIPTION
## 📦 What’s Added/Changed?

- Fixed controlled/uncontrolled desync in `DatePickerSingle` when `value` becomes `undefined`.
- Applied the same fix to `DatePickerRange`.
- Added regression Storybook scenarios:
  - `DatePickerSingle` → `ControlledReset`
  - `DatePickerRange` → `ControlledReset`
- Ensured clear/reset works in one click in controlled mode.
- Public API was not changed.

---

## 🧱 Type of Changes

- [ ] ✨ New component
- [x] ♻️ Enhancement to an existing component
- [x] 🐛 Bug fix
- [ ] 🎨 SCSS style update/refactor
- [x] 📖 Documentation / Storybook
- [x] 🧪 Tests (unit/visual)
- [ ] 🧰 Infrastructure / Configuration

---

## 🧪 Verification

- [x] Tests added or updated (if applicable)
- [ ] Visually checked in Storybook
- [ ] Verified in consuming project (if relevant)

---

## 🔍 Notes for Reviewers

- Please focus on controlled mode detection changes in:
  - `DatePickerSingle`
  - `DatePickerRange`
- In both components, `value={undefined}` is now treated as controlled-empty state (no fallback to internal uncontrolled state).
- Regression stories reproduce set/clear flow and verify immediate placeholder reset.

---

## 🔗 Related Issues/Tickets

Related to SCRUM-142

---

## ✅ Pre-Merge Checklist

- [ ] Component is covered by tests (if applicable)
- [x] Docs / Storybook updated
- [ ] All CI checks pass
- [x] No temporary logs, TODOs, or commented-out code
- [ ] All discussions resolved
- [ ] 2 approvals received
- [ ] Last commit is not self-approved

---

✅ **Thank you for contributing to the UI library!**
