### PR TITLE
Scrum 26 pagination

### DIFF
--- a/lib/components/molecules/Pagination/Pagination.module.scss
+++ b/lib/components/molecules/Pagination/Pagination.module.scss
@@ -143,6 +143,14 @@
   }
 }
 
+// Keep ellipsis input readable even if host app overrides global <input> colors.
+.paginationRoot .pageInput {
+  color: var(--color-dark-900);
+  -webkit-text-fill-color: var(--color-dark-900);
+  caret-color: var(--color-dark-900);
+  background-color: var(--color-light-100);
+}
+
 .itemsPerPageWrapper {
   display: flex;
   align-items: center;

--- a/lib/components/molecules/Pagination/Pagination.stories.tsx
+++ b/lib/components/molecules/Pagination/Pagination.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { expect, userEvent, waitFor, within } from '@storybook/test';
 import { useState } from 'react';
 import { Pagination } from './Pagination';
  
@@ -9,6 +10,7 @@ const meta: Meta<typeof Pagination> = {
   argTypes: {
     onPageChange: { action: 'pageChanged' },
     onItemsPerPageChange: { action: 'itemsPerPageChanged' },
+    pageSizeOptions: { control: 'object' },
   },
   parameters: {
     layout: 'centered',
@@ -92,6 +94,26 @@ export const SinglePage: Story = {
   name: 'Single Page (100 items)',
 };
 
+export const CustomPageSizeOptions: Story = {
+  ...Template,
+  args: {
+    ...Template.args,
+    pageSizeOptions: [25, 50, 100],
+    itemsPerPage: 25,
+  },
+  name: 'Custom Page Sizes (25/50/100)',
+};
+
+export const CurrentSizeNotInOptions: Story = {
+  ...Template,
+  args: {
+    ...Template.args,
+    pageSizeOptions: [10, 20, 30],
+    itemsPerPage: 15,
+  },
+  name: 'Current Size Not In Options',
+};
+
 export const InsideComponent: Story = {
   ...Template,
   args: {
@@ -109,4 +131,45 @@ export const MobileView: Story = {
     },
   },
   name: 'Mobile View',
+};
+
+export const BottomEdgeSelectOpensUp: Story = {
+  ...Template,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    Story => (
+      <div
+        style={{
+          width: '100%',
+          height: '95vh',
+          display: 'flex',
+          alignItems: 'flex-end',
+          justifyContent: 'center',
+          backgroundColor: 'black',
+          padding: '4px',
+          boxSizing: 'border-box',
+        }}
+      >
+        <Story />
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const selectTrigger = canvas.getByRole('combobox');
+
+    await userEvent.click(selectTrigger);
+
+    await waitFor(() => {
+      const content = canvasElement.ownerDocument.querySelector(
+        '[data-state="open"][data-side]'
+      ) as HTMLElement | null;
+
+      expect(content).not.toBeNull();
+      expect(content).toHaveAttribute('data-side', 'top');
+    });
+  },
+  name: 'Bottom Edge (Select Opens Up)',
 };

--- a/lib/components/molecules/Pagination/Pagination.tsx
+++ b/lib/components/molecules/Pagination/Pagination.tsx
@@ -18,6 +18,7 @@ export const Pagination = ({
   currentPage = 1,
   totalItems = 120,
   itemsPerPage = 10,
+  pageSizeOptions,
   onPageChange,
   onItemsPerPageChange,
   className,
@@ -29,6 +30,7 @@ export const Pagination = ({
     safeCurrentPage,
     visiblePages,
     selectOptions,
+    selectValue,
     handlePageInputChange,
     handlePageInputBlur,
     handleKeyDown,
@@ -38,6 +40,7 @@ export const Pagination = ({
     currentPage,
     totalItems,
     itemsPerPage,
+    pageSizeOptions,
     onPageChange,
     onItemsPerPageChange,
   });
@@ -104,7 +107,7 @@ export const Pagination = ({
             <Select
               items={selectOptions}
               size={'small'}
-              value={itemsPerPage.toString()}
+              value={selectValue}
               onValueChange={(value) => {
                 if (value) handleItemsPerPageChange(Number(value));
               }}
@@ -113,7 +116,7 @@ export const Pagination = ({
                 item: styles.paginationSelectItem,
                 trigger: styles.paginationSelectTrigger,
               }}
-              placeholder={itemsPerPage.toString()}
+              placeholder={selectValue}
             />
 
             <Typography variant="regular_14" className={styles.itemsPerPageLabel}>

--- a/lib/components/molecules/Pagination/Pagination.types.ts
+++ b/lib/components/molecules/Pagination/Pagination.types.ts
@@ -14,6 +14,11 @@ export interface PaginationProps {
   totalItems?: number;
   /** Number of items shown per page. */
   itemsPerPage?: number;
+  /**
+   * Optional page-size options for the selector.
+   * If omitted, defaults to `[10, 20, 30, 50, 100]`.
+   */
+  pageSizeOptions?: number[];
   /** Called when current page changes. Receives a clamped 1-based page index. */
   onPageChange: (page: number) => void;
   /**

--- a/lib/components/molecules/Pagination/hooks/usePagination/usePagination.tsx
+++ b/lib/components/molecules/Pagination/hooks/usePagination/usePagination.tsx
@@ -6,6 +6,7 @@ interface UsePaginationParams {
     currentPage?: number;
     totalItems?: number;
     itemsPerPage?: number;
+    pageSizeOptions?: number[];
     onPageChange: (page: number) => void;
     onItemsPerPageChange?: (count: number) => void;
 }
@@ -23,6 +24,7 @@ export const usePagination = ({
     currentPage = 1,
     totalItems = 0,
     itemsPerPage = 10,
+    pageSizeOptions,
     onPageChange,
     onItemsPerPageChange,
 }: UsePaginationParams) => {
@@ -101,6 +103,33 @@ export const usePagination = ({
         setActiveEllipsis(position);
     }, []);
 
+    const resolvedPageSizeOptions = useMemo(() => {
+        const sourceOptions = pageSizeOptions?.length ? pageSizeOptions : PAGE_SIZE_OPTIONS;
+        const uniqueOptions: number[] = [];
+
+        sourceOptions.forEach(option => {
+            if (!Number.isInteger(option) || option <= 0 || uniqueOptions.includes(option)) {
+                return;
+            }
+
+            uniqueOptions.push(option);
+        });
+
+        if (uniqueOptions.length === 0) {
+            PAGE_SIZE_OPTIONS.forEach(option => {
+                if (!uniqueOptions.includes(option)) {
+                    uniqueOptions.push(option);
+                }
+            });
+        }
+
+        if (!uniqueOptions.includes(safeItemsPerPage)) {
+            uniqueOptions.push(safeItemsPerPage);
+        }
+
+        return uniqueOptions;
+    }, [pageSizeOptions, safeItemsPerPage]);
+
     const visiblePages = useMemo<PageItem[]>(() => {
         if (totalPages <= 1) return [1];
 
@@ -125,11 +154,11 @@ export const usePagination = ({
     }, [totalPages, safeCurrentPage]);
 
     const selectOptions = useMemo(() => (
-        PAGE_SIZE_OPTIONS.map(option => ({
+        resolvedPageSizeOptions.map(option => ({
             value: option.toString(),
             label: option.toString()
         }))
-    ), []);
+    ), [resolvedPageSizeOptions]);
 
     return {
         inputPage,
@@ -137,7 +166,7 @@ export const usePagination = ({
         totalPages,
         safeCurrentPage,
         visiblePages,
-        pageSizeOptions: PAGE_SIZE_OPTIONS,
+        pageSizeOptions: resolvedPageSizeOptions,
         handlePageInputChange,
         handlePageInputBlur,
         handleKeyDown,

--- a/lib/components/molecules/Recaptcha/Recaptcha.tsx
+++ b/lib/components/molecules/Recaptcha/Recaptcha.tsx
@@ -1,4 +1,4 @@
-import { forwardRef, ReactElement } from 'react'
+import { ComponentClass, forwardRef, ReactElement } from 'react'
 import {
   default as ReCAPTCHA,
   ReCAPTCHA as ReCAPTCHAInstance,
@@ -15,6 +15,13 @@ import {
 } from 'components/molecules/Recaptcha/hook'
 
 import s from 'components/molecules/Recaptcha/Recaptcha.module.scss'
+
+/**
+ * Type compatibility shim for environments where `@types/react` versions can differ
+ * between the host app and `@types/react-google-recaptcha` (commonly in Yarn installs).
+ * We keep runtime behavior intact and only normalize JSX typing.
+ */
+const ReCAPTCHACompat = ReCAPTCHA as unknown as ComponentClass<ReCAPTCHAProps>
 
 /**
  * @interface RecaptchaProps
@@ -97,7 +104,7 @@ export const Recaptcha = forwardRef<ReCAPTCHAInstance, RecaptchaProps>(
         })}
       >
         <div className={s.recaptchaWrapper}>
-          <ReCAPTCHA
+          <ReCAPTCHACompat
             ref={ref}
             hl={'en'}
             theme={'dark'}

--- a/lib/components/molecules/Recaptcha/Recaptcha.tsx
+++ b/lib/components/molecules/Recaptcha/Recaptcha.tsx
@@ -1,4 +1,4 @@
-import { ComponentClass, forwardRef, ReactElement } from 'react'
+import { Component, ComponentClass, LegacyRef, forwardRef, ReactElement } from 'react'
 import {
   default as ReCAPTCHA,
   ReCAPTCHA as ReCAPTCHAInstance,
@@ -95,6 +95,9 @@ export const Recaptcha = forwardRef<ReCAPTCHAInstance, RecaptchaProps>(
       markAsFailed()
     }
 
+    // Keep forwarded ref support while normalizing cross-env React type mismatches.
+    const compatRef = ref as unknown as LegacyRef<Component<ReCAPTCHAProps>>
+
     return (
       <div
         className={clsx(s.container, {
@@ -105,7 +108,7 @@ export const Recaptcha = forwardRef<ReCAPTCHAInstance, RecaptchaProps>(
       >
         <div className={s.recaptchaWrapper}>
           <ReCAPTCHACompat
-            ref={ref}
+            ref={compatRef}
             hl={'en'}
             theme={'dark'}
             className={'recaptcha-core'}

--- a/lib/components/molecules/Select/Select.stories.tsx
+++ b/lib/components/molecules/Select/Select.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/react'
 
-import { expect, within } from '@storybook/test'
+import { expect, userEvent, waitFor, within } from '@storybook/test'
 
 import labelRadixStyles from '../LabelRadix/LabelRadix.module.scss'
 import styles from './Select.module.scss'
@@ -134,5 +134,93 @@ export const Error: Story = {
     await expect(label).toHaveClass(labelRadixStyles.invalid)
     await expect(trigger).toHaveClass(styles.triggerError)
     await expect(canvas.getByText('This field is required')).toBeInTheDocument()
+  },
+}
+
+export const AutoCollisionNearBottom: Story = {
+  args: {
+    label: 'Select near bottom',
+    items: baseItems,
+  },
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    Story => (
+      <div
+        style={{
+          width: '100%',
+          height: '95vh',
+          display: 'flex',
+          alignItems: 'flex-end',
+          justifyContent: 'center',
+          padding: '4px',
+          boxSizing: 'border-box',
+        }}
+      >
+        <div style={{ width: '200px' }}>
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const trigger = canvas.getByRole('combobox', { name: 'Select near bottom' })
+
+    await userEvent.click(trigger)
+
+    await waitFor(() => {
+      const content = canvasElement.ownerDocument.querySelector(
+        '[data-state="open"][data-side]'
+      ) as HTMLElement | null
+
+      expect(content).not.toBeNull()
+      expect(content).toHaveAttribute('data-side', 'top')
+    })
+  },
+}
+
+export const AutoCollisionNearTop: Story = {
+  args: {
+    label: 'Select near top',
+    items: baseItems,
+  },
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    Story => (
+      <div
+        style={{
+          width: '100%',
+          height: '95vh',
+          display: 'flex',
+          alignItems: 'flex-start',
+          justifyContent: 'center',
+          padding: '4px',
+          boxSizing: 'border-box',
+        }}
+      >
+        <div style={{ width: '200px' }}>
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement)
+    const trigger = canvas.getByRole('combobox', { name: 'Select near top' })
+
+    await userEvent.click(trigger)
+
+    await waitFor(() => {
+      const content = canvasElement.ownerDocument.querySelector(
+        '[data-state="open"][data-side]'
+      ) as HTMLElement | null
+
+      expect(content).not.toBeNull()
+      expect(content).toHaveAttribute('data-side', 'bottom')
+    })
   },
 }

--- a/lib/components/molecules/Select/Select.tsx
+++ b/lib/components/molecules/Select/Select.tsx
@@ -1,6 +1,5 @@
 import { type ComponentRef, forwardRef, ReactNode, useId } from 'react'
 
-import * as ScrollArea from '@radix-ui/react-scroll-area'
 import * as RadixSelect from '@radix-ui/react-select'
 import ArrowDownSimple from 'assets/icons/components/ArrowDownSimple'
 import { clsx } from 'clsx'
@@ -36,6 +35,10 @@ export type SelectProps = {
   onValueChange?: (value: string) => void
   collisionPadding?: number | Partial<Record<'top' | 'right' | 'bottom' | 'left', number>>
   avoidCollisions?: boolean
+  side?: 'top' | 'bottom'
+  align?: 'start' | 'center' | 'end'
+  sideOffset?: number
+  alignOffset?: number
   /**
    * @deprecated Use `classNames.trigger`.
    */
@@ -62,7 +65,7 @@ export type SelectProps = {
  * - Supports icons in options
  * - Controlled and uncontrolled value handling
  * - Customizable size via 'size' prop affecting padding, font sizes, and arrow icon size
- * - Scroll buttons for long lists (if max-height is set)
+ * - Collision-aware popper positioning with configurable side/alignment
  *
  * ## Example usage:
  * ```tsx
@@ -91,6 +94,11 @@ export type SelectProps = {
  * - `props.id` - Optional id for the select trigger
  * - `props.size` - Determines the size of the select component, affecting padding, font size, and icon size. Available options are 'medium' or 'small'.
  * - `props.collisionPadding` - The padding between the content and the viewport edge. Can be a single number or a partial object of paddings. Defaults to `20`.
+ * - `props.avoidCollisions` - Enables adaptive placement when there is not enough space. Defaults to `true`.
+ * - `props.side` - Preferred dropdown side (`'top' | 'bottom'`). Defaults to `'bottom'`.
+ * - `props.align` - Alignment against the trigger (`'start' | 'center' | 'end'`). Defaults to `'start'`.
+ * - `props.sideOffset` - Distance (px) between trigger and content along the side axis. Defaults to `0`.
+ * - `props.alignOffset` - Distance (px) along the alignment axis. Defaults to `0`.
  * - `props.classNames` - An object of custom class names for the component's parts, allowing for targeted style overrides. Can include `label`, `trigger`, `content`, and `item`.
  *
  * @todo SCRUM-26 (tech debt): after one stable cycle, remove deprecated `className`, `contentClassName`, and `labelClassName`
@@ -116,7 +124,11 @@ export const Select = forwardRef<ComponentRef<typeof RadixSelect.Trigger>, Selec
       size = 'medium',
       onValueChange,
       collisionPadding = 20,
-      avoidCollisions = false,
+      avoidCollisions = true,
+      side = 'bottom',
+      align = 'start',
+      sideOffset = 0,
+      alignOffset = 0,
       classNames = {},
       ...rest
     },
@@ -170,36 +182,32 @@ export const Select = forwardRef<ComponentRef<typeof RadixSelect.Trigger>, Selec
               position={'popper'}
               avoidCollisions={avoidCollisions}
               collisionPadding={collisionPadding}
+              side={side}
+              align={align}
+              sideOffset={sideOffset}
+              alignOffset={alignOffset}
               className={clsx(s.content, classNames.content, contentClassName)}
             >
-              <ScrollArea.Root type={'auto'}>
-                <RadixSelect.Viewport asChild>
-                  <ScrollArea.Viewport>
-                    {items.map(item => (
-                      <RadixSelect.Item
-                        key={item.value}
-                        value={item.value}
-                        data-slot={'item'}
-                        className={clsx(s.item, classNames.item, s[`item--${size}`])}
+              <RadixSelect.Viewport>
+                {items.map(item => (
+                  <RadixSelect.Item
+                    key={item.value}
+                    value={item.value}
+                    data-slot={'item'}
+                    className={clsx(s.item, classNames.item, s[`item--${size}`])}
+                  >
+                    <RadixSelect.ItemText asChild>
+                      <Typography
+                        variant={size === 'small' ? 'regular_14' : 'regular_16'}
+                        className={s.list}
+                        data-slot={'item-text'}
                       >
-                        <RadixSelect.ItemText asChild>
-                          <Typography
-                            variant={size === 'small' ? 'regular_14' : 'regular_16'}
-                            className={s.list}
-                            data-slot={'item-text'}
-                          >
-                            {item.icon && item.icon} {item.label}
-                          </Typography>
-                        </RadixSelect.ItemText>
-                      </RadixSelect.Item>
-                    ))}
-                  </ScrollArea.Viewport>
-                </RadixSelect.Viewport>
-
-                <ScrollArea.Scrollbar orientation={'vertical'}>
-                  <ScrollArea.Thumb />
-                </ScrollArea.Scrollbar>
-              </ScrollArea.Root>
+                        {item.icon && item.icon} {item.label}
+                      </Typography>
+                    </RadixSelect.ItemText>
+                  </RadixSelect.Item>
+                ))}
+              </RadixSelect.Viewport>
             </RadixSelect.Content>
           </RadixSelect.Portal>
         </RadixSelect.Root>


### PR DESCRIPTION
## 📦 What’s Added/Changed?

- Stabilized `Select` behavior for positioning and collisions:
  - removed nested `ScrollArea` from `Select` content viewport path,
  - enabled `avoidCollisions` by default,
  - added popper control props: `side`, `align`, `sideOffset`, `alignOffset`.
- Improved `Pagination` API:
  - added `pageSizeOptions?: number[]`,
  - replaced hardcoded page-size handling with fallback + sanitize + dedupe logic,
  - ensured current `itemsPerPage` is still selectable even if missing from provided options.
- Updated Storybook coverage:
  - `Select` stories for collision behavior near viewport top/bottom,
  - `Pagination` stories for custom page sizes and “current size not in options” scenario,
  - `Pagination` bottom-edge story where select opens upward.
- Fixed pagination ellipsis input visibility in consuming app:
  - strengthened `.pageInput` text/caret/background styles to prevent host-app global input color overrides.

---

## 🧱 Type of Changes

- [ ] ✨ New component
- [x] ♻️ Enhancement to an existing component
- [x] 🐛 Bug fix
- [x] 🎨 SCSS style update/refactor
- [x] 📖 Documentation / Storybook
- [ ] 🧪 Tests (unit/visual)
- [ ] 🧰 Infrastructure / Configuration

---

## 🧪 Verification

- [x] Tests added or updated (if applicable)
- [x] Visually checked in Storybook
- [ ] Verified in consuming project (if relevant)

---

## 🔍 Notes for Reviewers

- Please focus review on:
  - `Select` collision defaults and new popper props compatibility,
  - `Pagination` page-size option resolution behavior,
  - ellipsis input style hardening in host applications.
- Scroll-lock/scrollbar-gutter changes are intentionally out of scope for this PR.

---

## 🔗 Related Issues/Tickets

- SCRUM-26

---

## ✅ Pre-Merge Checklist

- [ ] Component is covered by tests (if applicable)
- [x] Docs / Storybook updated
- [ ] All CI checks pass
- [x] No temporary logs, TODOs, or commented-out code
- [ ] All discussions resolved
- [ ] 2 approvals received
- [ ] Last commit is not self-approved

---

✅ **Thank you for contributing to the UI library!**
