### PR TITLE
feat: add ScrollAreaRadix orientation prop

### DIFF
--- a/lib/components/atoms/ScrollAreaRadix/ScrollAreaRadix.tsx
+++ b/lib/components/atoms/ScrollAreaRadix/ScrollAreaRadix.tsx
@@ -1,26 +1,39 @@
 import { ReactElement, ReactNode } from 'react'
 
 import { Corner, Root, Scrollbar, Thumb, Viewport } from '@radix-ui/react-scroll-area'
+import { clsx } from 'clsx'
 import { useHorizontalWheelScroll } from 'components/atoms/ScrollAreaRadix/useHorizontalWheelScroll'
 
 import styles from './ScrollAreaRadix.module.scss'
+
+export type ScrollAreaOrientation = 'vertical' | 'horizontal' | 'both'
 
 export interface CustomScrollAreaProps {
   children: ReactNode
   className?: string
   viewportClassName?: string
+  orientation?: ScrollAreaOrientation
 }
 
 /**
  * A customizable scroll area component built on top of Radix UI's ScrollArea primitives.
  *
- * Provides vertical and horizontal scrolling with styled scrollbars, and supports
- * horizontal scrolling via mouse wheel using the `useHorizontalWheelScroll` custom hook.
+ * Provides styled scrollbars for vertical, horizontal, or bidirectional scrolling.
+ * Horizontal scrolling can also be enhanced with mouse wheel support via the
+ * `useHorizontalWheelScroll` custom hook.
+ *
+ * By default, the component preserves the original behavior and renders both
+ * vertical and horizontal scrollbars (`orientation="both"`). Existing usages
+ * without the `orientation` prop do not need to be changed.
+ *
+ * Use `orientation="vertical"` for page-level or layout scroll containers where
+ * horizontal page scrolling must be prevented.
  *
  * @component
  * @example
  * ```tsx
  * import { ScrollAreaRadix } from 'components/atoms/ScrollAreaRadix/ScrollAreaRadix'
+ *
  * const MyComponent = () => (
  *   <ScrollAreaRadix className="my-scroll-area" viewportClassName="my-viewport">
  *     <div>Scrollable content here</div>
@@ -28,37 +41,60 @@ export interface CustomScrollAreaProps {
  * )
  * ```
  *
+ * @example
+ * ```tsx
+ * <ScrollAreaRadix orientation="vertical">
+ *   <div>Vertically scrollable content here</div>
+ * </ScrollAreaRadix>
+ * ```
+ *
  * @param {CustomScrollAreaProps} props - Props for the ScrollAreaRadix component.
- * @param {React.ReactNode} props.children - The content to be rendered inside the scrollable area.
- * @param {string} [props.className] - Optional CSS class to apply to the root element for custom styling.
- * @param {string} [props.viewportClassName] - Optional CSS class to apply to the viewport element for custom styling.
+ * @param {React.ReactNode} props.children - The content rendered inside the scrollable area.
+ * @param {string} [props.className] - Optional CSS class applied to the root element.
+ * @param {string} [props.viewportClassName] - Optional CSS class applied to the viewport element.
+ * @param {'vertical' | 'horizontal' | 'both'} [props.orientation='both'] - Controls which scroll axis is enabled. Defaults to `both` for backward compatibility.
  * @returns {React.ReactElement} The rendered scroll area component.
  *
  * @remarks
- * Uses `useHorizontalWheelScroll` internally to enhance UX for horizontal content layouts.
-
+ * `useHorizontalWheelScroll` is enabled only when horizontal scrolling is active
+ * (`orientation="horizontal"` or `orientation="both"`).
  */
 
 export const ScrollAreaRadix = (props: CustomScrollAreaProps): ReactElement => {
-  const { children, className, viewportClassName } = props
-  const scrollRef = useHorizontalWheelScroll()
+  const { children, className, viewportClassName, orientation = 'both' } = props
+
+  const showVertical = orientation === 'vertical' || orientation === 'both'
+  const showHorizontal = orientation === 'horizontal' || orientation === 'both'
+  const scrollRef = useHorizontalWheelScroll({ enabled: showHorizontal })
 
   return (
-    <Root className={`${styles.ScrollAreaRoot} ${className}`}>
+    <Root className={clsx(styles.ScrollAreaRoot, className)}>
       <Viewport
         tabIndex={0}
         ref={scrollRef}
-        className={`${styles.ScrollAreaViewport} ${viewportClassName}`}
+        className={clsx(
+          styles.ScrollAreaViewport,
+          orientation === 'vertical' && styles.ScrollAreaViewportVertical,
+          orientation === 'horizontal' && styles.ScrollAreaViewportHorizontal,
+          viewportClassName
+        )}
       >
         {children}
       </Viewport>
-      <Scrollbar className={`${styles.ScrollAreaScrollbar}`} orientation={'vertical'}>
-        <Thumb className={`${styles.ScrollAreaThumb}`} />
-      </Scrollbar>
-      <Scrollbar className={`${styles.ScrollAreaScrollbar}`} orientation={'horizontal'}>
-        <Thumb className={`${styles.ScrollAreaThumb}`} />
-      </Scrollbar>
-      <Corner className={`${styles.ScrollAreaCorner}`} />
+
+      {showVertical && (
+        <Scrollbar className={styles.ScrollAreaScrollbar} orientation={'vertical'}>
+          <Thumb className={styles.ScrollAreaThumb} />
+        </Scrollbar>
+      )}
+
+      {showHorizontal && (
+        <Scrollbar className={styles.ScrollAreaScrollbar} orientation={'horizontal'}>
+          <Thumb className={styles.ScrollAreaThumb} />
+        </Scrollbar>
+      )}
+
+      {showVertical && showHorizontal && <Corner className={styles.ScrollAreaCorner} />}
     </Root>
   )
 }

--- a/lib/components/atoms/ScrollAreaRadix/useHorizontalWheelScroll.ts
+++ b/lib/components/atoms/ScrollAreaRadix/useHorizontalWheelScroll.ts
@@ -1,29 +1,24 @@
 import { useEffect, useRef } from 'react'
 
+type UseHorizontalWheelScrollParams = {
+  enabled?: boolean
+}
+
 /**
  * A React hook that enables horizontal scrolling using the vertical mouse wheel.
  *
- * This hook is useful when you want to allow horizontal scrolling in areas where
- * horizontal overflow is present, but the default mouse wheel behavior only scrolls vertically.
- *
- * The hook returns a ref that should be attached to a scrollable container (typically a div
- * with `overflow-x: auto`). It adds a `wheel` event listener that maps vertical scroll input
- * (`deltaY`) to horizontal scrolling (`scrollLeft`).
- *
- * ⚠️ The event listener is added as non-passive to allow preventing the default vertical scroll
- * behavior. Make sure this does not interfere with other scrollable areas on the page.
- *
  * @returns A ref to be attached to a scrollable element.
- *
- * @example
- * const scrollRef = useHorizontalWheelScroll();
- * return <div ref={scrollRef} style={{ overflowX: 'auto' }}>…</div>
  */
-
-export const useHorizontalWheelScroll = () => {
+export const useHorizontalWheelScroll = ({
+  enabled = true,
+}: UseHorizontalWheelScrollParams = {}) => {
   const ref = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
+    if (!enabled) {
+      return
+    }
+
     const el = ref.current
 
     if (!el) {
@@ -41,7 +36,7 @@ export const useHorizontalWheelScroll = () => {
     el.addEventListener('wheel', onWheel, { passive: true })
 
     return () => el.removeEventListener('wheel', onWheel)
-  }, [])
+  }, [enabled])
 
   return ref
 }


### PR DESCRIPTION
## 📦 What’s Added/Changed?

- Added optional `orientation` prop to `ScrollAreaRadix`.
- Preserved existing behavior by default with `orientation="both"`.
- Added support for vertical-only and horizontal-only scroll modes.
- Disabled horizontal wheel handling when horizontal scrolling is not active.
- Updated ScrollAreaRadix documentation for the new orientation behavior.

---

## 🧱 Type of Changes

- [ ] ✨ New component
- [x] ♻️ Enhancement to an existing component
- [ ] 🐛 Bug fix
- [x] 🎨 SCSS style update/refactor
- [x] 📖 Documentation / Storybook
- [ ] 🧪 Tests (unit/visual)
- [ ] 🧰 Infrastructure / Configuration

---

## 🧪 Verification

- [ ] Tests added or updated (if applicable)
- [ ] Visually checked in Storybook
- [x] Verified in consuming project (if relevant)

---

## 🔍 Notes for Reviewers

`orientation` is backward-compatible. Existing usages without the prop keep the previous bidirectional scroll behavior.

Recommended usage for page-level layout scroll containers:

```tsx
<ScrollAreaRadix orientation="vertical">
  {children}
</ScrollAreaRadix>